### PR TITLE
Fix useOssFragment fails to update when dataIDs change

### DIFF
--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -117,9 +117,9 @@ const useOssFragment = function (fragmentDef, fragmentRef: any, ): FragmentResul
 
   useEffect(() => {
     if (prev && prev.fragmentRef) {
-      const { getDataIDsFromObject } = environment.unstable_internal;
-      const prevIDs = getDataIDsFromObject(fragments, prev.fragmentRef);
-      const nextIDs = getDataIDsFromObject(fragments, fragmentRef);
+      const { getDataIDsFromFragment } = environment.unstable_internal;
+      const prevIDs = getDataIDsFromFragment(fragments, prev.fragmentRef);
+      const nextIDs = getDataIDsFromFragment(fragments, fragmentRef);
       if (prev.environment !== environment ||
         !areEqual(prevIDs, nextIDs)) {
         resolver.dispose();


### PR DESCRIPTION
getDataIDsFromObject expects a fragmentSpec, which is not the case here. This fixes broken behavior that just fails silently, resulting is no update.