### PR TITLE
types: makes useQuery a generic type and accept a response type.

### DIFF
--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -25,9 +25,9 @@ export type ContainerResult = {
 };
 
 
-export interface RenderProps {
+export interface RenderProps<T> {
     error: Error,
-    props: Object,
+    props: T,
     retry: () => void,
     cached?: boolean
 };

--- a/src/UseQueryFetcher.ts
+++ b/src/UseQueryFetcher.ts
@@ -5,10 +5,10 @@ import * as areEqual from 'fbjs/lib/areEqual';
 import { UseQueryProps, RenderProps, OperationContextProps, STORE_THEN_NETWORK, NETWORK_ONLY, STORE_OR_NETWORK } from './RelayHooksType';
 
 
-class UseQueryFetcher {
+class UseQueryFetcher<T> {
     _queryFetcher: ReactRelayQueryFetcher;
     _forceUpdate: any;
-    _lastResult: RenderProps;
+    _lastResult: RenderProps<T>;
 
 
     constructor(forceUpdate) {
@@ -42,7 +42,7 @@ class UseQueryFetcher {
         this._lastResult = renderProps;
     }
 
-    _execute(environment, query, variables, dataFrom = STORE_OR_NETWORK): RenderProps {
+    _execute(environment, query, variables, dataFrom = STORE_OR_NETWORK): RenderProps<T> {
         if (!query) {
             this._queryFetcher.dispose();
             return this.getResult(environment, query, variables, { empty: true });
@@ -88,7 +88,7 @@ class UseQueryFetcher {
         }
     }
 
-    getResult(environment, query, variables, result: { empty?: boolean, error?: Error, snapshot?: Snapshot, cached?: boolean }): RenderProps {
+    getResult(environment, query, variables, result: { empty?: boolean, error?: Error, snapshot?: Snapshot, cached?: boolean }): RenderProps<T> {
         if (!result) {
             return;
         }
@@ -110,6 +110,7 @@ class UseQueryFetcher {
                 }
             }
         }
+        //@ts-ignore
         return renderProps;
     }
 

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -8,8 +8,8 @@ import { UseQueryProps } from './RelayHooksType';
 
 import UseQueryFetcher from './UseQueryFetcher';
 
-type Reference = {
-    queryFetcher: UseQueryFetcher,
+type Reference<T> = {
+    queryFetcher: UseQueryFetcher<T>,
 }
 
 function useDeepCompare<T>(value: T): T {
@@ -22,17 +22,17 @@ function useDeepCompare<T>(value: T): T {
 
 
 
-const useQuery = function (props: UseQueryProps)  {
+const useQuery = function <T>(props: UseQueryProps)  {
     const { environment } = useContext(ReactRelayContext);
     const [, forceUpdate] = useState(null);
     const { query, variables, dataFrom } = props;
     const latestVariables = useDeepCompare(variables);
     const prev = usePrevious({ environment, query, latestVariables});
     
-    const ref = useRef<Reference>();
+    const ref = useRef<Reference<T>>();
     if (ref.current === null || ref.current === undefined) {
         ref.current = {
-            queryFetcher: new UseQueryFetcher(forceUpdate),
+            queryFetcher: new UseQueryFetcher<T>(forceUpdate),
         };
     }
     const { queryFetcher } = ref.current;


### PR DESCRIPTION
Hello!

This PR makes a useQuery hook accept a generic type for a response. It is typed in a very similar way as Apollo hooks are typed. It improves a DX a lot while working with useQuery.

Let me know if you are ok with that change and if there is anything that needs to be addressed before merging.