### PR TITLE
Support relay 6.0.0

### DIFF
--- a/examples/relay-hook-example/todo/js/app.js
+++ b/examples/relay-hook-example/todo/js/app.js
@@ -95,21 +95,21 @@ const isServer = typeof window === 'undefined';
 const LayoutTodo = ({ userId }) => {
   console.log("LayoutTodo", userId, isServer);
   useQueryExp
-  /*const { props, error, retry, cached } = useQueryExp(
+  const { props, error, retry, cached } = useQueryExp(
     QueryApp,
     { userId },
     {
-      fetchPolicy: "store-and-network"
+      fetchPolicy: "store-or-network"
     }
-  );*/
-  const { props, error, retry, cached } = useQuery({
+  );
+  /*const { props, error, retry, cached } = useQuery({
     query: QueryApp,
     variables: {
       // Mock authenticated ID that matches database
       userId,
     },
     dataFrom: "STORE_THEN_NETWORK"
-  });
+  });*/
 
   console.log("renderer", props, cached)
   if (props && props.user) {

--- a/examples/relay-hook-example/todo/js/app.js
+++ b/examples/relay-hook-example/todo/js/app.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 
 import { useState } from 'react';
 
-import { useQuery, RelayEnvironmentProvider } from 'relay-hooks';
+import { useQuery, RelayEnvironmentProvider, useQueryExp } from 'relay-hooks';
 import {
   Environment,
   Network,
@@ -28,6 +28,7 @@ import {
 } from 'relay-runtime';
 
 import TodoApp, { fragmentSpec } from './components/TodoApp';
+//import { useQuery, RelayEnvironmentProvider } from 'relay-hooks';
 
 import TodoTextInput from './components/TodoTextInput';
 import type { appQueryResponse } from 'relay/appQuery.graphql';
@@ -92,13 +93,22 @@ const AppTodo = function (appProps) {
 }
 const isServer = typeof window === 'undefined';
 const LayoutTodo = ({ userId }) => {
-  console.log("LayoutTodo", userId, isServer)
+  console.log("LayoutTodo", userId, isServer);
+  useQueryExp
+  /*const { props, error, retry, cached } = useQueryExp(
+    QueryApp,
+    { userId },
+    {
+      fetchPolicy: "store-and-network"
+    }
+  );*/
   const { props, error, retry, cached } = useQuery({
     query: QueryApp,
     variables: {
       // Mock authenticated ID that matches database
       userId,
-    }
+    },
+    dataFrom: "STORE_THEN_NETWORK"
   });
 
   console.log("renderer", props, cached)

--- a/examples/relay-hook-example/todo/js/components/TodoList.js
+++ b/examples/relay-hook-example/todo/js/components/TodoList.js
@@ -29,7 +29,7 @@ type Props = {|
   +user: TodoList_user,
 |};
 
-const fragmentSpec = graphql`
+/*const fragmentSpec = graphql`
     fragment TodoList_user on User {
       todos(
         first: 2147483647 # max GraphQLInt
@@ -49,7 +49,7 @@ const fragmentSpec = graphql`
       ...Todo_user
     }
   `;
-
+*/
 const TodoList = (props) => {
   const { refetch, user } = props;
   //const { refetch } = props;
@@ -69,7 +69,7 @@ const TodoList = (props) => {
       {userId: "you"},  
       null,  
       () => { console.log('Refetch done') },
-      {force: true},  
+      {force: true, fetchPolicy: "store-and-network"},  
     );
     //response.dispose();
 

--- a/examples/relay-hook-example/todo/package.json
+++ b/examples/relay-hook-example/todo/package.json
@@ -16,7 +16,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-relay": "^6.0.0",
+    "react-relay": "^4.0.0",
     "relay-hooks": "file:../../../relay-hooks-1.3.0-a8.tgz",
     "whatwg-fetch": "3.0.0",
     "isomorphic-fetch": "2.2.1",
@@ -46,7 +46,7 @@
     "flow-bin": "^0.94.0",
     "flow-typed": "^2.5.1",
     "prettier": "^1.16.4",
-    "relay-compiler": "^6.0.0",
+    "relay-compiler": "^4.0.0",
     "webpack": "^4.29.6",
     "webpack-dev-server": "^3.2.1"
   },

--- a/examples/relay-hook-example/todo/package.json
+++ b/examples/relay-hook-example/todo/package.json
@@ -16,8 +16,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-relay": "^4.0.0",
-    "relay-hooks": "1.2.7",
+    "react-relay": "^6.0.0",
+    "relay-hooks": "file:../../../relay-hooks-1.3.0-a8.tgz",
     "whatwg-fetch": "3.0.0",
     "isomorphic-fetch": "2.2.1",
     "es6-promise": "4.2.8"
@@ -46,7 +46,7 @@
     "flow-bin": "^0.94.0",
     "flow-typed": "^2.5.1",
     "prettier": "^1.16.4",
-    "relay-compiler": "^4.0.0",
+    "relay-compiler": "^6.0.0",
     "webpack": "^4.29.6",
     "webpack-dev-server": "^3.2.1"
   },

--- a/examples/relay-hook-example/todo/yarn.lock
+++ b/examples/relay-hook-example/todo/yarn.lock
@@ -5132,15 +5132,15 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-react-relay@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-6.0.0.tgz#2a54274a471ef801a465704e58f1db91059ad1d3"
-  integrity sha512-F0UO50TNIyfkTaCnKgbniATIWPpaX0ukQ5QPdaRRwL1qxslx90Umi83XaaiHyy1etKVePMZ+DHCd1aV7yw1AKA==
+react-relay@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-4.0.0.tgz#000f63ca3ae179b4415ee11765d04bc2fe4278da"
+  integrity sha512-Z7O+zM5oUmUWqOiPv7Z3L8a9cNCXare8wkUfDgtTBl048wXXtkAWTHTP0QZdViRSLmNHmEwHo/y0lBpZ7iy6SQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
     nullthrows "^1.1.0"
-    relay-runtime "6.0.0"
+    relay-runtime "4.0.0"
 
 react@^16.8.4:
   version "16.8.4"
@@ -5304,14 +5304,15 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-6.0.0.tgz#a70ecb39b59dea507261aeda704c071326d69d5e"
-  integrity sha512-8K8cCwrOTqu3usF8GXQ+JEgxcTxJ5qVFqfNpfMYrRpMraXrBmykcLRpj38p2MxtcjyqkE2ZnUe5huW5/469obA==
+relay-compiler@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-4.0.0.tgz#d97dd2819d3b92669599c9cfec8049c9b487be67"
+  integrity sha512-IljjuroVEBWfNgZHb9Qm2YeAH6GRagM64eRYIdyVN4kitY1u1Hitle4000y3A1XRwjgrEuD4CuryFK0ktGaszA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.0.0"
     "@babel/parser" "^7.0.0"
+    "@babel/polyfill" "^7.0.0"
     "@babel/runtime" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
@@ -5322,7 +5323,7 @@ relay-compiler@^6.0.0:
     fbjs "^1.0.0"
     immutable "~3.7.6"
     nullthrows "^1.1.0"
-    relay-runtime "6.0.0"
+    relay-runtime "4.0.0"
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
@@ -5332,10 +5333,10 @@ relay-compiler@^6.0.0:
   dependencies:
     "@restart/hooks" "^0.3.1"
 
-relay-runtime@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-6.0.0.tgz#073ec2408f41a28c3a7310d71dd5f42f8e4e4bf3"
-  integrity sha512-zIXQqFfe0zBCVzKbMGEPMvKFxfbE3pY2RbZsKBvHAr/vMDj6OX9E+f4R4udE5xvMbI7g+baYFHi2I9NDEydGaQ==
+relay-runtime@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-4.0.0.tgz#5cf50f52e3ea56ec81f0b5fed05b03e99a9e3906"
+  integrity sha512-Fd5nAMNfySINAYPf1zgtcYbCk33pO5ANiYfaMhKYzukfc2GCmn6RP7NEpG69GxVezu/E1aOxo72t+Y1NspDV8A==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"

--- a/examples/relay-hook-example/todo/yarn.lock
+++ b/examples/relay-hook-example/todo/yarn.lock
@@ -5132,15 +5132,15 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-react-relay@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-4.0.0.tgz#000f63ca3ae179b4415ee11765d04bc2fe4278da"
-  integrity sha512-Z7O+zM5oUmUWqOiPv7Z3L8a9cNCXare8wkUfDgtTBl048wXXtkAWTHTP0QZdViRSLmNHmEwHo/y0lBpZ7iy6SQ==
+react-relay@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-6.0.0.tgz#2a54274a471ef801a465704e58f1db91059ad1d3"
+  integrity sha512-F0UO50TNIyfkTaCnKgbniATIWPpaX0ukQ5QPdaRRwL1qxslx90Umi83XaaiHyy1etKVePMZ+DHCd1aV7yw1AKA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
     nullthrows "^1.1.0"
-    relay-runtime "4.0.0"
+    relay-runtime "6.0.0"
 
 react@^16.8.4:
   version "16.8.4"
@@ -5304,15 +5304,14 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-4.0.0.tgz#d97dd2819d3b92669599c9cfec8049c9b487be67"
-  integrity sha512-IljjuroVEBWfNgZHb9Qm2YeAH6GRagM64eRYIdyVN4kitY1u1Hitle4000y3A1XRwjgrEuD4CuryFK0ktGaszA==
+relay-compiler@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-6.0.0.tgz#a70ecb39b59dea507261aeda704c071326d69d5e"
+  integrity sha512-8K8cCwrOTqu3usF8GXQ+JEgxcTxJ5qVFqfNpfMYrRpMraXrBmykcLRpj38p2MxtcjyqkE2ZnUe5huW5/469obA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.0.0"
     "@babel/parser" "^7.0.0"
-    "@babel/polyfill" "^7.0.0"
     "@babel/runtime" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
@@ -5323,20 +5322,20 @@ relay-compiler@^4.0.0:
     fbjs "^1.0.0"
     immutable "~3.7.6"
     nullthrows "^1.1.0"
-    relay-runtime "4.0.0"
+    relay-runtime "6.0.0"
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"relay-hooks@file:../../../relay-hooks-1.2.7-a4.tgz":
-  version "1.2.7-a4"
-  resolved "file:../../../relay-hooks-1.2.7-a4.tgz#82d6d0dc01d7fbac3dd6291fd86947d178a3b5da"
+"relay-hooks@file:../../../relay-hooks-1.3.0-a8.tgz":
+  version "1.3.0-a8"
+  resolved "file:../../../relay-hooks-1.3.0-a8.tgz#9c6a96a218705efa0ca2e7ea4a49e54bf9097fb5"
   dependencies:
     "@restart/hooks" "^0.3.1"
 
-relay-runtime@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-4.0.0.tgz#5cf50f52e3ea56ec81f0b5fed05b03e99a9e3906"
-  integrity sha512-Fd5nAMNfySINAYPf1zgtcYbCk33pO5ANiYfaMhKYzukfc2GCmn6RP7NEpG69GxVezu/E1aOxo72t+Y1NspDV8A==
+relay-runtime@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-6.0.0.tgz#073ec2408f41a28c3a7310d71dd5f42f8e4e4bf3"
+  integrity sha512-zIXQqFfe0zBCVzKbMGEPMvKFxfbE3pY2RbZsKBvHAr/vMDj6OX9E+f4R4udE5xvMbI7g+baYFHi2I9NDEydGaQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-hooks",
-  "version": "1.2.7",
+  "version": "1.3.0-a8",
   "keywords": [
     "graphql",
     "relay",

--- a/src/FragmentPagination.ts
+++ b/src/FragmentPagination.ts
@@ -453,7 +453,7 @@ class FragmentPagination {
                     fragmentVariables,
                     paginatingVariables.totalCount,
                 ),
-                operation.node,
+                operation.node || operation.request.node,
             );
             const nextData = resolver.resolve();
 

--- a/src/FragmentPagination.ts
+++ b/src/FragmentPagination.ts
@@ -17,17 +17,14 @@ import {
     getVariablesFromObject
 } from 'relay-runtime';
 
-export type RefetchOptions = {
-    force?: boolean,
-    fetchPolicy?: 'store-or-network' | 'network-only',
-};
+
 
 export type ObserverOrCallback = Observer<void> | ((error: Error) => any);
 import * as ReactRelayQueryFetcher from 'react-relay/lib/ReactRelayQueryFetcher';
 import * as invariant from 'fbjs/lib/invariant';
 import * as warning from 'fbjs/lib/warning';
 import * as areEqual from 'fbjs/lib/areEqual';
-import { ContainerResult } from './RelayHooksType';
+import { ContainerResult, RefetchOptions } from './RelayHooksType';
 
 
 
@@ -393,12 +390,12 @@ class FragmentPagination {
             };
         });
         // hack 6.0.0
-        if(getVariablesFromObject.length === 2) {
+        if (getVariablesFromObject.length === 2) {
             fragmentVariables = getVariablesFromObject(
-              fragments,
-              propsFragment
+                fragments,
+                propsFragment
             );
-          } else {
+        } else {
             fragmentVariables = getVariablesFromObject(
                 // NOTE: We pass empty operationVariables because we want to prefer
                 // the variables from the fragment owner
@@ -408,7 +405,7 @@ class FragmentPagination {
                 fragmentOwners,
             );
         }
-        
+
         fragmentVariables = {
             ...rootVariables,
             ...fragmentVariables,
@@ -441,6 +438,9 @@ class FragmentPagination {
         const cacheConfig: CacheConfig = options
             ? { force: !!options.force }
             : undefined;
+        if (cacheConfig != null && options && options.metadata != null) {
+            cacheConfig.metadata = options.metadata;
+        }
         const request = getRequest(connectionConfig.query);
         const operation = createOperationDescriptor(request, fetchVariables);
 

--- a/src/FragmentPagination.ts
+++ b/src/FragmentPagination.ts
@@ -27,7 +27,6 @@ import * as ReactRelayQueryFetcher from 'react-relay/lib/ReactRelayQueryFetcher'
 import * as invariant from 'fbjs/lib/invariant';
 import * as warning from 'fbjs/lib/warning';
 import * as areEqual from 'fbjs/lib/areEqual';
-import * as forEachObject from 'fbjs/lib/forEachObject';
 import { ContainerResult } from './RelayHooksType';
 
 
@@ -383,7 +382,7 @@ class FragmentPagination {
         // For extra safety, we make sure the rootVariables include the
         // variables from all owners in this fragmentSpec, even though they
         // should all point to the same owner
-        forEachObject(fragments, (__, key) => {
+        Object.keys(fragments).forEach(key => {
             const fragmentOwner = fragmentOwners[key];
             const fragmentOwnerVariables = Array.isArray(fragmentOwner)
                 ? fragmentOwner[0].variables || {}
@@ -393,14 +392,23 @@ class FragmentPagination {
                 ...fragmentOwnerVariables,
             };
         });
-        fragmentVariables = getVariablesFromObject(
-            // NOTE: We pass empty operationVariables because we want to prefer
-            // the variables from the fragment owner
-            {},
-            fragments,
-            propsFragment,
-            fragmentOwners,
-        );
+        // hack 6.0.0
+        if(getVariablesFromObject.length === 2) {
+            fragmentVariables = getVariablesFromObject(
+              fragments,
+              propsFragment
+            );
+          } else {
+            fragmentVariables = getVariablesFromObject(
+                // NOTE: We pass empty operationVariables because we want to prefer
+                // the variables from the fragment owner
+                {},
+                fragments,
+                propsFragment,
+                fragmentOwners,
+            );
+        }
+        
         fragmentVariables = {
             ...rootVariables,
             ...fragmentVariables,

--- a/src/FragmentRefetch.ts
+++ b/src/FragmentRefetch.ts
@@ -7,17 +7,13 @@ import {
     Variables,
     createOperationDescriptor,
     getRequest,
-    Snapshot
+    Snapshot,
+    CacheConfig
 } from 'relay-runtime';
-
-export type RefetchOptions = {
-    force?: boolean,
-    fetchPolicy?: FetchPolicy,
-};
 
 export type ObserverOrCallback = Observer<void> | ((error: Error) => any);
 import * as ReactRelayQueryFetcher from 'react-relay/lib/ReactRelayQueryFetcher';
-import { ContainerResult, FetchPolicy } from './RelayHooksType';
+import { ContainerResult, RefetchOptions } from './RelayHooksType';
 import { isStorePolicy, isNetworkPolicy } from './Utils';
 
 
@@ -61,7 +57,10 @@ class FragmentRefetch {
             ? { ...fetchVariables, ...renderVariables }
             : fetchVariables;
 
-        const cacheConfig = options ? { force: !!options.force } : undefined;
+        const cacheConfig: CacheConfig = options ? { force: !!options.force } : undefined;
+        if (cacheConfig != null && options && options.metadata != null) {
+            cacheConfig.metadata = options.metadata;
+        }
 
         const observer =
             typeof observerOrCallback === 'function'

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -3,7 +3,7 @@ import {
     RelayContext,
     FragmentSpecResolver,
 } from 'relay-runtime/lib/RelayStoreTypes';
-import { OperationType } from 'relay-runtime';
+import { OperationType, CacheConfig } from 'relay-runtime';
 
 
 export const NETWORK_ONLY = 'NETWORK_ONLY';
@@ -16,6 +16,12 @@ interface DataFromEnum {
     STORE_OR_NETWORK,
     STORE_ONLY
 };
+export type FetchPolicy =
+| 'store-only'
+| 'store-or-network'
+| 'store-and-network'
+| 'network-only';
+
 export type DataFrom = keyof DataFromEnum;
 
 export type ContainerResult = {
@@ -31,6 +37,7 @@ export interface RenderProps<T extends OperationType> {
 };
 
 export interface UseQueryProps<T extends OperationType> {
+    cacheConfig?: CacheConfig,
     dataFrom?: DataFrom,
     query: GraphQLTaggedNode,
     variables: T['variables'],

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -48,3 +48,8 @@ export type OperationContextProps = {
     relay: RelayContext,
 };
 
+export type RefetchOptions = {
+    force?: boolean,
+    fetchPolicy?: FetchPolicy,
+    metadata?: {[key: string]: any}
+};

--- a/src/UseQueryFetcher.ts
+++ b/src/UseQueryFetcher.ts
@@ -2,9 +2,6 @@ import * as ReactRelayQueryFetcher from 'react-relay/lib/ReactRelayQueryFetcher'
 import { Snapshot } from 'relay-runtime/lib/RelayStoreTypes';
 import {
     RenderProps,
-    STORE_THEN_NETWORK,
-    NETWORK_ONLY,
-    STORE_OR_NETWORK,
     FetchPolicy
 } from './RelayHooksType';
 import { 
@@ -34,19 +31,6 @@ class UseQueryFetcher<TOperationType extends OperationType> {
     dispose() {
         this._queryFetcher.dispose();
     }
-
-    /*execute(environment, query, variables): RenderProps {
-        if (!query) {
-            this._queryFetcher.dispose();
-            return this.getOperationContext({ operation: null, relay: { environment, variables } });
-        } else {
-            this._queryFetcher.disposeRequest();
-            const { createOperationDescriptor, getRequest, } = environment.unstable_internal;
-            const request = getRequest(query);
-            const operation = createOperationDescriptor(request, variables);
-            return this.getOperationContext({ operation: operation, relay: { environment, variables: operation.variables } });
-        }
-    }*/
 
     lookupInStore(environment, operation, fetchPolicy): Snapshot {
         if (isStorePolicy(fetchPolicy) && environment.check(operation.root)) {
@@ -78,7 +62,7 @@ class UseQueryFetcher<TOperationType extends OperationType> {
             const querySnapshot = isNetwork ? this._queryFetcher.fetch({
                 cacheConfig,
                 environment,
-                onDataChange: (params: { //TODO BETTER
+                onDataChange: (params: {
                     error?: Error,
                     snapshot?: Snapshot,
                 }): void => {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,0 +1,24 @@
+import { STORE_OR_NETWORK, STORE_THEN_NETWORK, NETWORK_ONLY, FetchPolicy, DataFrom, STORE_ONLY } from "./RelayHooksType";
+
+export const convertDataFrom = (dataFrom: DataFrom = STORE_OR_NETWORK): FetchPolicy => {
+    switch (dataFrom) {
+        case NETWORK_ONLY:
+            return "network-only";
+        case STORE_THEN_NETWORK:
+            return "store-and-network";
+        case STORE_ONLY:
+            return "store-only";
+        default:
+            return "store-or-network";
+    }
+}
+
+export const isNetworkPolicy = (policy: FetchPolicy, storeSnapshot): boolean => {
+    return (policy === "network-only" ||
+        policy === "store-and-network" ||
+        (policy === "store-or-network" && !storeSnapshot));
+}
+
+export const isStorePolicy = (policy: FetchPolicy): boolean => {
+    return policy !== "network-only";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from 'react-relay';
 
 export {default as useQuery} from './useQuery';
+export { useQueryExp } from './useQuery';
 export {default as useFragment} from './useFragment';
 export {useMutation} from './useMutation';
 export {default as useOssFragment} from './useOssFragment';

--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -134,6 +134,13 @@ const useOssFragment = function (fragmentDef, fragmentRef: any, ): FragmentResul
   }, [environment, fragmentRef]);
 
   function _getFragmentVariables(fRef= fragmentRef): Variables {
+    // hack v6.0.0
+    if(getVariablesFromFragment.length === 2) {
+      return getVariablesFromFragment(
+        fragments,
+        fRef
+      );
+    }
     return getVariablesFromFragment(
       // NOTE: We pass empty operationVariables because we want to prefer
       // the variables from the fragment owner

--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef, useContext } from "react";
-import * as mapObject from 'fbjs/lib/mapObject';
 import * as areEqual from 'fbjs/lib/areEqual';
 import {
   RelayFeatureFlags,
@@ -13,10 +12,8 @@ import { RelayContext } from 'relay-runtime/lib/RelayStoreTypes';
 
 import { ContainerResult } from './RelayHooksType';
 import {
-  Disposable,
   IEnvironment,
   GraphQLTaggedNode,
-  Observable,
   Observer,
   Variables,
   getFragmentOwner

--- a/src/usePrevious.ts
+++ b/src/usePrevious.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import * as ReactRelayQueryFetcher from 'react-relay/lib/ReactRelayQueryFetcher';
 
 const usePrevious = function usePrevious(value): any {
     const ref = useRef();


### PR DESCRIPTION
* Improved:
  * Added the possibility to use the `useQueryExp` hooks in line with the experimental version of relay-experimental. This ensures backward compatibility and easier migration in subsequent versions.
  * The compatibility of relay-hooks with the official versions 4.0.0, 5.0.0 and 6.0.0 has been confirmed.

* Fixed:
  * #34 
  * #35 