### PR TITLE
Added Generic for QueryVariables in useRefetch

### DIFF
--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -64,7 +64,7 @@ export type ArrayKeyReturnType<T extends ArrayKeyType> = (
     arg: T,
 ) => NonNullable<NonNullable<T[0]>[' $data']>[0];
 
-export type PaginationFunction = {
+export type PaginationFunction<TVariables extends Variables = Variables> = {
     loadMore: (
         connectionConfig: ConnectionConfig,
         pageSize: number,
@@ -77,14 +77,14 @@ export type PaginationFunction = {
         connectionConfig: ConnectionConfig,
         totalCount: number,
         observerOrCallback: ObserverOrCallback,
-        refetchVariables: Variables,
+        refetchVariables: TVariables,
     ) => Disposable;
 };
 
-export type RefetchableFunction = (
-    refetchVariables: Variables | ((fragmentVariables: Variables) => Variables),
+export type RefetchableFunction<TVariables extends Variables = Variables> = (
+    refetchVariables: TVariables | ((fragmentVariables: TVariables) => TVariables),
     options?: {
-        renderVariables?: Variables;
+        renderVariables?: TVariables;
         observerOrCallback?: ObserverOrCallback;
         refetchOptions?: RefetchOptions;
     },
@@ -92,7 +92,7 @@ export type RefetchableFunction = (
 
 export type RefetchFunction<TVariables extends Variables = Variables> = (
     taggedNode: GraphQLTaggedNode,
-    refetchVariables: TVariables | ((fragmentVariables: Variables) => TVariables),
+    refetchVariables: TVariables | ((fragmentVariables: TVariables) => TVariables),
     renderVariables?: TVariables,
     observerOrCallback?: ObserverOrCallback,
     options?: RefetchOptions,

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -90,7 +90,7 @@ export type RefetchableFunction = (
     },
 ) => Disposable;
 
-export type RefetchFunction<TVariables extends Variables> = (
+export type RefetchFunction<TVariables extends Variables = Variables> = (
     taggedNode: GraphQLTaggedNode,
     refetchVariables: TVariables | ((fragmentVariables: Variables) => TVariables),
     renderVariables?: TVariables,

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -90,10 +90,10 @@ export type RefetchableFunction = (
     },
 ) => Disposable;
 
-export type RefetchFunction = (
+export type RefetchFunction<TVariables extends Variables> = (
     taggedNode: GraphQLTaggedNode,
-    refetchVariables: Variables | ((fragmentVariables: Variables) => Variables),
-    renderVariables?: Variables,
+    refetchVariables: TVariables | ((fragmentVariables: Variables) => TVariables),
+    renderVariables?: TVariables,
     observerOrCallback?: ObserverOrCallback,
     options?: RefetchOptions,
 ) => Disposable;

--- a/src/usePagination.ts
+++ b/src/usePagination.ts
@@ -1,24 +1,36 @@
 import useOssFragment from './useOssFragment';
 import { PaginationFunction } from './RelayHooksType';
-import { GraphQLTaggedNode } from 'relay-runtime';
+import { GraphQLTaggedNode, OperationType } from 'relay-runtime';
 import { KeyType, KeyReturnType, $Call, ArrayKeyType, ArrayKeyReturnType } from './RelayHooksType';
 
-function usePagination<TKey extends KeyType>(
+function usePagination<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [$Call<KeyReturnType<TKey>>, PaginationFunction];
-function usePagination<TKey extends KeyType>(
+): [$Call<KeyReturnType<TKey>>, PaginationFunction<TOperationType['variables']>];
+function usePagination<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [$Call<KeyReturnType<TKey>> | null, PaginationFunction];
-function usePagination<TKey extends ArrayKeyType>(
+): [$Call<KeyReturnType<TKey>> | null, PaginationFunction<TOperationType['variables']>];
+function usePagination<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>, PaginationFunction];
-function usePagination<TKey extends ArrayKeyType>(
+): [
+    ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>,
+    PaginationFunction<TOperationType['variables']>,
+];
+function usePagination<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null, PaginationFunction] {
+): [
+    ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null,
+    PaginationFunction<TOperationType['variables']>,
+] {
     const [data, { loadMore, hasMore, isLoading, refetchConnection }] = useOssFragment(
         fragmentNode,
         fragmentRef,

--- a/src/useRefetch.ts
+++ b/src/useRefetch.ts
@@ -4,19 +4,25 @@ import { GraphQLTaggedNode, OperationType } from 'relay-runtime';
 
 import { KeyType, KeyReturnType, $Call, ArrayKeyType, ArrayKeyReturnType } from './RelayHooksType';
 
-function useRefetch<TKey extends KeyType, TOperationType extends OperationType>(
+function useRefetch<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
 ): [$Call<KeyReturnType<TKey>>, RefetchFunction<TOperationType['variables']>];
-function useRefetch<TKey extends KeyType, TOperationType extends OperationType>(
+function useRefetch<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): [$Call<KeyReturnType<TKey>> | null, RefetchFunction<TOperationType['variables']>];
-function useRefetch<TKey extends ArrayKeyType, TOperationType extends OperationType>(
+function useRefetch<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
 ): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>, RefetchFunction<TOperationType['variables']>];
-function useRefetch<TKey extends ArrayKeyType, TOperationType extends OperationType>(
+function useRefetch<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): [

--- a/src/useRefetch.ts
+++ b/src/useRefetch.ts
@@ -1,25 +1,28 @@
 import useOssFragment from './useOssFragment';
 import { RefetchFunction } from './RelayHooksType';
-import { GraphQLTaggedNode } from 'relay-runtime';
+import { GraphQLTaggedNode, OperationType } from 'relay-runtime';
 
 import { KeyType, KeyReturnType, $Call, ArrayKeyType, ArrayKeyReturnType } from './RelayHooksType';
 
-function useRefetch<TKey extends KeyType>(
+function useRefetch<TKey extends KeyType, TOperationType extends OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [$Call<KeyReturnType<TKey>>, RefetchFunction];
-function useRefetch<TKey extends KeyType>(
+): [$Call<KeyReturnType<TKey>>, RefetchFunction<TOperationType['variables']>];
+function useRefetch<TKey extends KeyType, TOperationType extends OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [$Call<KeyReturnType<TKey>> | null, RefetchFunction];
-function useRefetch<TKey extends ArrayKeyType>(
+): [$Call<KeyReturnType<TKey>> | null, RefetchFunction<TOperationType['variables']>];
+function useRefetch<TKey extends ArrayKeyType, TOperationType extends OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>, RefetchFunction];
-function useRefetch<TKey extends ArrayKeyType>(
+): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>, RefetchFunction<TOperationType['variables']>];
+function useRefetch<TKey extends ArrayKeyType, TOperationType extends OperationType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null, RefetchFunction] {
+): [
+    ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null,
+    RefetchFunction<TOperationType['variables']>,
+] {
     const [data, { refetch }] = useOssFragment(fragmentNode, fragmentRef);
 
     return [data, refetch];

--- a/src/useRefetchable.ts
+++ b/src/useRefetchable.ts
@@ -1,28 +1,40 @@
 import { useCallback, useMemo } from 'react';
 import useOssFragment from './useOssFragment';
 import { RefetchableFunction, RefetchOptions } from './RelayHooksType';
-import { GraphQLTaggedNode, getFragment, Variables, ObserverOrCallback } from 'relay-runtime';
+import { GraphQLTaggedNode, getFragment, ObserverOrCallback, OperationType } from 'relay-runtime';
 
 import * as invariant from 'fbjs/lib/invariant';
 
 import { KeyType, KeyReturnType, $Call, ArrayKeyType, ArrayKeyReturnType } from './RelayHooksType';
 
-function useRefetchable<TKey extends KeyType>(
+function useRefetchable<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [$Call<KeyReturnType<TKey>>, RefetchableFunction];
-function useRefetchable<TKey extends KeyType>(
+): [$Call<KeyReturnType<TKey>>, RefetchableFunction<TOperationType['variables']>];
+function useRefetchable<TKey extends KeyType, TOperationType extends OperationType = OperationType>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [$Call<KeyReturnType<TKey>> | null, RefetchableFunction];
-function useRefetchable<TKey extends ArrayKeyType>(
+): [$Call<KeyReturnType<TKey>> | null, RefetchableFunction<TOperationType['variables']>];
+function useRefetchable<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>, RefetchableFunction];
-function useRefetchable<TKey extends ArrayKeyType>(
+): [
+    ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>,
+    RefetchableFunction<TOperationType['variables']>,
+];
+function useRefetchable<
+    TKey extends ArrayKeyType,
+    TOperationType extends OperationType = OperationType
+>(
     fragmentInput: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null, RefetchableFunction] {
+): [
+    ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null,
+    RefetchableFunction<TOperationType['variables']>,
+] {
     const fragmentNode = getFragment(fragmentInput);
 
     const [data, { refetch }] = useOssFragment(fragmentInput, fragmentRef);
@@ -61,9 +73,11 @@ function useRefetchable<TKey extends ArrayKeyType>(
 
     const refetchable = useCallback(
         (
-            refetchVariables: Variables | ((fragmentVariables: Variables) => Variables),
+            refetchVariables:
+                | TOperationType['variables']
+                | ((fragmentVariables: TOperationType['variables']) => TOperationType['variables']),
             options: {
-                renderVariables?: Variables;
+                renderVariables?: TOperationType['variables'];
                 observerOrCallback?: ObserverOrCallback;
                 refetchOptions?: RefetchOptions;
             } = {},


### PR DESCRIPTION
extend useRefetch to use Generic by generated Query type
`
useRefetch<TKey extends ArrayKeyType, TOperationType extends OperationType>
`