### PR TITLE
Reflect that options is optional in typing

### DIFF
--- a/src/useLazyLoadQuery.ts
+++ b/src/useLazyLoadQuery.ts
@@ -7,7 +7,7 @@ import { useMemoOperationDescriptor } from './useQuery';
 export const useLazyLoadQuery: <TOperationType extends OperationType>(
     gqlQuery: GraphQLTaggedNode,
     variables: TOperationType['variables'],
-    options: QueryOptions,
+    options?: QueryOptions,
 ) => RenderProps<TOperationType> = <TOperationType extends OperationType>(
     gqlQuery,
     variables,

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -25,7 +25,7 @@ export function useMemoOperationDescriptor(
 export const useQuery: <TOperationType extends OperationType>(
     gqlQuery: GraphQLTaggedNode,
     variables: TOperationType['variables'],
-    options: QueryOptions,
+    options?: QueryOptions,
 ) => RenderProps<TOperationType> = <TOperationType extends OperationType>(
     gqlQuery,
     variables,


### PR DESCRIPTION
Just below the line I changed, you can see that `options` is defaulted to `{}` if not passed.