### PR TITLE
Make variables optional

### DIFF
--- a/src/useLazyLoadQuery.ts
+++ b/src/useLazyLoadQuery.ts
@@ -4,15 +4,11 @@ import useRelayEnvironment from './useRelayEnvironment';
 import useQueryFetcher from './useQueryFetcher';
 import { useMemoOperationDescriptor } from './useQuery';
 
-export const useLazyLoadQuery: <TOperationType extends OperationType>(
+export const useLazyLoadQuery = <TOperationType extends OperationType>(
     gqlQuery: GraphQLTaggedNode,
-    variables: TOperationType['variables'],
-    options?: QueryOptions,
-) => RenderProps<TOperationType> = <TOperationType extends OperationType>(
-    gqlQuery,
-    variables,
-    options = {} as QueryOptions,
-) => {
+    variables: TOperationType['variables'] = {},
+    options: QueryOptions = {},
+): RenderProps<TOperationType> => {
     const environment = useRelayEnvironment();
     const query = useMemoOperationDescriptor(gqlQuery, variables);
     const queryFetcher = useQueryFetcher<TOperationType>(query);

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -22,15 +22,11 @@ export function useMemoOperationDescriptor(
     return useMemo(() => createOperation(gqlQuery, memoVariables), [gqlQuery, memoVariables]);
 }
 
-export const useQuery: <TOperationType extends OperationType>(
+export const useQuery = <TOperationType extends OperationType>(
     gqlQuery: GraphQLTaggedNode,
-    variables: TOperationType['variables'],
-    options?: QueryOptions,
-) => RenderProps<TOperationType> = <TOperationType extends OperationType>(
-    gqlQuery,
-    variables,
-    options = {},
-) => {
+    variables: TOperationType['variables'] = {},
+    options: QueryOptions = {},
+): RenderProps<TOperationType> => {
     const environment = useRelayEnvironment();
     const query = useMemoOperationDescriptor(gqlQuery, variables);
     const queryFetcher = useQueryFetcher<TOperationType>();


### PR DESCRIPTION
Fixes #62 

As discussed in #61 and #62, this PR makes `variables` optional for `useQuery` and `useLazyLoadQuery`. 

I cleaned up the typing on these 2 hooks so that we're not having to duplicate the typing logic.

Also I filed the request upstream to `react-relay`, https://github.com/facebook/relay/issues/3045

/cc @morrys 