### PR TITLE
skip option in useQuery & useLazyLoadQuery similar to apollo

### DIFF
--- a/__tests__/ReactRelayQueryRenderer-test.js
+++ b/__tests__/ReactRelayQueryRenderer-test.js
@@ -56,12 +56,14 @@ const QueryRendererHook = props => {
     query,
     variables,
     cacheConfig,
-    fetchKey
+    fetchKey,
+    skip
   } = props;
   const { cached, ...relays } = useQuery(query, variables, {
     networkCacheConfig: cacheConfig,
     fetchPolicy,
-    fetchKey
+    fetchKey,
+    skip
   });
 
   return <React.Fragment>{render(relays)}</React.Fragment>;
@@ -147,6 +149,57 @@ describe("ReactRelayQueryRenderer", () => {
   });
 
   describe("when initialized", () => {
+
+    
+
+    it("skip", () => {
+      const renderer = ReactTestRenderer.create(
+        <PropsSetter>
+        <ReactRelayQueryRenderer
+          query={TestQuery}
+          cacheConfig={cacheConfig}
+          environment={environment}
+          render={render}
+          variables={variables}
+          skip={true}
+        />
+        </PropsSetter>
+      );
+      expect(environment.execute.mock.calls.length).toBe(0);
+      environment.mockClear();
+      render.mockClear();
+
+      renderer.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+        skip: false
+      });
+
+      expect(environment.execute.mock.calls.length).toBe(1);
+      render.mockClear();
+      environment.mock.resolve(TestQuery, response);
+      const owner = createOperationDescriptor(TestQuery, variables);
+      expect({
+        error: null,
+        props: {
+          node: {
+            id: '4',
+
+            __fragments: {
+              TestFragment: {},
+            },
+
+            __fragmentOwner: owner.request,
+            __id: '4',
+          },
+        },
+        retry: expect.any(Function),
+      }).toBeRendered();
+
+    });
+
     it("fetches the query", () => {
       ReactTestRenderer.create(
         <ReactRelayQueryRenderer

--- a/src/QueryFetcher.ts
+++ b/src/QueryFetcher.ts
@@ -94,12 +94,20 @@ class QueryFetcher<TOperationType extends OperationType> {
         retain: (environment, query) => Disposable = (environment, query): Disposable =>
             environment.retain(query),
     ): RenderProps<TOperationType> {
-        const { fetchPolicy = defaultPolicy, networkCacheConfig, fetchKey } = options;
+        const { fetchPolicy = defaultPolicy, networkCacheConfig, fetchKey, skip } = options;
         let storeSnapshot;
         const retry = (cacheConfigOverride: CacheConfig = networkCacheConfig): void => {
             this.disposeRequest();
             this.fetch(cacheConfigOverride, false);
         };
+        if(skip) {
+            return {
+                cached: false,
+                retry,
+                error: null,
+                props: {},
+            }
+        }
         this.clearTemporaryRetain();
         const isDiffEnvQuery = this.isDiffEnvQuery(environment, query);
         if (isDiffEnvQuery || fetchPolicy !== this.fetchPolicy || fetchKey !== this.fetchKey) {

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -48,6 +48,7 @@ export type QueryOptions = {
     fetchPolicy?: FetchPolicy;
     fetchKey?: string | number;
     networkCacheConfig?: CacheConfig;
+    skip?: boolean;
 };
 
 export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT


### PR DESCRIPTION
issue: https://github.com/relay-tools/relay-hooks/issues/57

Added skip option in useQuery similar to apollo https://www.apollographql.com/docs/react/data/queries/#options
