### PR TITLE
change skip return & improved typing useQuery & useLazyLoadQuery

### DIFF
--- a/src/QueryFetcher.ts
+++ b/src/QueryFetcher.ts
@@ -105,7 +105,7 @@ class QueryFetcher<TOperationType extends OperationType> {
                 cached: false,
                 retry,
                 error: null,
-                props: {},
+                props: undefined,
             };
         }
         this.clearTemporaryRetain();

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -28,7 +28,7 @@ export type ContainerResult = {
 
 export interface RenderProps<T extends OperationType> {
     error: Error;
-    props: T['response'];
+    props: T['response'] | null | undefined;
     retry: (_cacheConfigOverride?: CacheConfig) => void;
     cached?: boolean;
 }


### PR DESCRIPTION
https://github.com/relay-tools/relay-hooks/issues/69

Changed the return value when the skip property is true.
Now useQuery & useLazyLoadQuery return as a value of `props`:
 * **null** - when is loading
 * **undefined** - for skip or not found in store
 * **T['response']** - when found data