### PR TITLE
Deprecated flag PREFER_FRAGMENT_OWNER_OVER_CONTEXT  removed

### DIFF
--- a/src/RelayEnvironmentProvider.tsx
+++ b/src/RelayEnvironmentProvider.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { Environment, RelayFeatureFlags } from 'relay-runtime';
+import { Environment } from 'relay-runtime';
 import { ReactRelayContext } from './ReactRelayContext'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 export const RelayEnvironmentProvider = function(props: {
     children: React.ReactNode;
-    environment?: Environment;
+    environment: Environment;
 }): JSX.Element {
-    RelayFeatureFlags.PREFER_FRAGMENT_OWNER_OVER_CONTEXT = true;
+    const context = React.useMemo(() => ({ environment: props.environment }), [props.environment]);
     return (
-        <ReactRelayContext.Provider value={{ environment: props.environment, variables: {} }}>
-            {props.children}
-        </ReactRelayContext.Provider>
+        <ReactRelayContext.Provider value={context}>{props.children}</ReactRelayContext.Provider>
     );
 };

--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { RelayFeatureFlags, GraphQLTaggedNode } from 'relay-runtime';
+import { GraphQLTaggedNode } from 'relay-runtime';
 import { FragmentResolver } from './FragmentResolver';
 import {
     ContainerResult,
@@ -27,7 +27,6 @@ export function useOssFragment<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
 ): [ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> | null, FragmentResolver] {
-    RelayFeatureFlags.PREFER_FRAGMENT_OWNER_OVER_CONTEXT = true;
     const environment = useRelayEnvironment();
     const [, forceUpdate] = useState<ContainerResult>(null);
     const ref = useRef<{ resolver: FragmentResolver }>(null);


### PR DESCRIPTION
* removed deprecated flag from useOssFragment
* removed deprecated flag & variables context from RelayEnvironmentProvider 
* added useMemo for environment in RelayEnvironmentProvider 