### PR TITLE
ES modules build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 lib
+es
 *.tgz
 coverage
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "main": "lib/index.js",
   "module": "es/index.js",
+  "unpkg": "es/index.js",
   "license": "MIT",
   "description": "Relay Hooks",
   "author": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ssr"
   ],
   "main": "lib/index.js",
+  "module": "es/index.js",
   "license": "MIT",
   "description": "Relay Hooks",
   "author": {
@@ -20,8 +21,8 @@
     "url": "https://github.com/relay-tools/relay-hooks"
   },
   "scripts": {
-    "clean": "rimraf lib",
-    "compile": "npm run clean && tsc",
+    "clean": "rimraf lib es",
+    "compile": "npm run clean && tsc && tsc --module ES2015 --target ES2015 --outDir es",
     "build": "npm run compile && npm run test",
     "test": "cross-env NODE_ENV=test jest --coverage",
     "format": "prettier --write \"src/**/*.{j,t}s*\"",


### PR DESCRIPTION
## Overview

This PR adds support for an ES modules build.

After running `npm run build` or `npm run compile`, ES modules will be emitted in `es`. Downstream packages should be able to seamlessly switch to the new modules through use of the updated `module` field in package.json.