### PR TITLE
Update useOssFragment.tsx

### DIFF
--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -30,9 +30,15 @@ export function useOssFragment<TKey extends ArrayKeyType>(
     const environment = useRelayEnvironment();
     const [, forceUpdate] = useState<ContainerResult>(null);
     const ref = useRef<{ resolver: FragmentResolver }>(null);
+    const mountedRef = useRef(false);
+    useEffect(() => {
+        mountedRef.current = true;
+    }, []);
     if (ref.current === null || ref.current === undefined) {
         ref.current = {
-            resolver: new FragmentResolver(forceUpdate),
+            resolver: new FragmentResolver((id) => {
+                if (mountedRef.current) forceUpdate(id);
+            }),
         };
     }
 


### PR DESCRIPTION
Prevent react from complaining `Can't perform a React state update on an unmounted component` in StrictMode.

This should fix the problem mentioned in PR https://github.com/relay-tools/relay-hooks/pull/107

However, the tests are failing. I currently have no idea about making the tests work.

Not only in StrictMode, but this also prevents the case that `forceUpdate` is called before the first render finishes.

CC: @morrys 