### PR TITLE
feat observe fetch query

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ After Relay's core team shared information about the the initial differences in 
   * **useQuery**: it is the same as `useLazyLoadQuery` but does not use suspense, it allows you to use hooks without having to migrate the application in concurrent mode and its return is the same as the QueryRenderer HOC
   * **useRefetch**: it is the same as `useRefetchable`, allows you to migrate the Refetch Container without changing the fragment specifications
   * **conditional useQuery & useLazyLoadQuery**: added `skip`: [Optional] If skip is true, the query will be skipped entirely
+  * **observe the execution of the query in the network in useQuery & useLazyLoadQuery**: added `fetchObserver`: [Optional] A fetchObserver can be passed to observe the execution of the query in the network
 
 * why use relay-hooks?
 
@@ -83,6 +84,8 @@ In addition to `query` (first argument) and `variables` (second argument), `useQ
 `networkCacheConfig`: [Optional] Object containing cache config options for the network layer. Note the the network layer may contain an additional query response cache which will reuse network responses for identical queries. If you want to bypass this cache completely, pass {force: true} as the value for this option.
 
 `skip`: [Optional] If skip is true, the query will be skipped entirely.
+
+`fetchObserver`: [Optional] A fetchObserver can be passed to observe the execution of the query in the network
 
 ```ts
 import {useQuery, graphql } from 'relay-hooks';

--- a/__tests__/ReactRelayFragmentContainer-test.tsx
+++ b/__tests__/ReactRelayFragmentContainer-test.tsx
@@ -22,6 +22,14 @@ import {
     NETWORK_ONLY,
 } from '../src';
 
+function createHooks(component, options?: any) {
+    const result = ReactTestRenderer.create(component, options);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 const ReactRelayFragmentContainer = {
     createContainer: (Component, spec) => (props) => {
         const { user, ...others } = props;
@@ -174,7 +182,7 @@ describe('ReactRelayFragmentContainer', () => {
     });
     /*
   it("passes non-fragment props to the component", () => {
-    ReactTestRenderer.create(
+    createHooks(
       // changed, add user {null}
       <ContextSetter environment={environment}>
         <TestContainer bar={1} foo="foo" user={null} />
@@ -194,7 +202,7 @@ describe('ReactRelayFragmentContainer', () => {
   });
   
   it("passes through null props", () => {
-    ReactTestRenderer.create(
+    createHooks(
       <ContextSetter environment={environment}>
         <TestContainer user={null} />
       </ContextSetter>
@@ -214,7 +222,7 @@ describe('ReactRelayFragmentContainer', () => {
     it('resolves & subscribes fragment props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -246,7 +254,7 @@ describe('ReactRelayFragmentContainer', () => {
     it('re-renders on subscription callback', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -285,7 +293,7 @@ describe('ReactRelayFragmentContainer', () => {
 
     it('resolves new props', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -330,7 +338,7 @@ describe('ReactRelayFragmentContainer', () => {
 
     it('resolves new props when ids dont change', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -376,7 +384,7 @@ describe('ReactRelayFragmentContainer', () => {
 
     it('does not update for same props/data', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -399,7 +407,7 @@ describe('ReactRelayFragmentContainer', () => {
       .node;
     const scalar = 42;
     const fn = () => null;
-    const instance = ReactTestRenderer.create(
+    const instance = createHooks(
       <ContextSetter environment={environment}>
         <TestContainer fn={fn} nil={null} scalar={scalar} user={userPointer} />
       </ContextSetter>
@@ -424,7 +432,7 @@ describe('ReactRelayFragmentContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -454,7 +462,7 @@ describe('ReactRelayFragmentContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -481,7 +489,7 @@ describe('ReactRelayFragmentContainer', () => {
 
     it('always updates for non-scalar props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer arr={[]} obj={{}} user={userPointer} />
             </ContextSetter>,
@@ -545,7 +553,7 @@ describe('ReactRelayFragmentContainer', () => {
     let containerRef;
     let componentRef;
 
-    ReactTestRenderer.create(
+    createHooks(
       <ContextSetter environment={environment} variables={{}}>
         <TestNoProxyContainer
           user={null}
@@ -579,7 +587,7 @@ describe('ReactRelayFragmentContainer', () => {
 
     const UnwrappedComponent = unwrapContainer(TestUnwrappingContainer);
 
-    const renderer = ReactTestRenderer.create(
+    const renderer = createHooks(
       <UnwrappedComponent user={{ id: "4", name: "Mark" }} />
     );
 

--- a/__tests__/ReactRelayPaginationContainer-test.tsx
+++ b/__tests__/ReactRelayPaginationContainer-test.tsx
@@ -16,6 +16,14 @@ import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 import { usePagination, RelayEnvironmentProvider, useRelayEnvironment } from '../src';
 
+function createHooks(component, options?: any) {
+    const result = ReactTestRenderer.create(component, options);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 const ReactRelayPaginationContainer = {
     createContainer: (Component, spec, connectionConfigs) => (props: any) => {
         const { user, ...others } = props;
@@ -272,7 +280,7 @@ describe('ReactRelayPaginationContainer', () => {
   });*/
 
     it('passes non-fragment props to the component', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer bar={1} foo="foo" />
             </ContextSetter>,
@@ -295,7 +303,7 @@ describe('ReactRelayPaginationContainer', () => {
     });
 
     it('passes through null props', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={null} />
             </ContextSetter>,
@@ -319,7 +327,7 @@ describe('ReactRelayPaginationContainer', () => {
     it('resolves & subscribes fragment props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -376,7 +384,7 @@ describe('ReactRelayPaginationContainer', () => {
     it('re-renders on subscription callback', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -419,7 +427,7 @@ describe('ReactRelayPaginationContainer', () => {
 
     it('resolves new props', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -477,7 +485,7 @@ describe('ReactRelayPaginationContainer', () => {
     it('resolves new props when ids dont change', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -537,7 +545,7 @@ describe('ReactRelayPaginationContainer', () => {
     it('resolves new props when ids dont change after paginating', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -627,7 +635,7 @@ describe('ReactRelayPaginationContainer', () => {
 
     it('does not update for same props/data', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -650,7 +658,7 @@ describe('ReactRelayPaginationContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} nil={null} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -676,7 +684,7 @@ describe('ReactRelayPaginationContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -708,7 +716,7 @@ describe('ReactRelayPaginationContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -737,7 +745,7 @@ describe('ReactRelayPaginationContainer', () => {
 
     it('always updates for non-scalar props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer arr={[]} obj={{}} user={userPointer} />
             </ContextSetter>,
@@ -876,7 +884,7 @@ describe('ReactRelayPaginationContainer', () => {
         );
 
         expect(() => {
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer />
                 </ContextSetter>,
@@ -887,7 +895,7 @@ describe('ReactRelayPaginationContainer', () => {
     describe('hasMore()', () => {
         beforeEach(() => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1001,7 +1009,7 @@ describe('ReactRelayPaginationContainer', () => {
         beforeEach(() => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
             environment.mock.clearCache();
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1113,7 +1121,7 @@ describe('ReactRelayPaginationContainer', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
             environment.mock.clearCache();
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1426,7 +1434,7 @@ describe('ReactRelayPaginationContainer', () => {
 
         it('should not load more data if container is unmounted', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1452,7 +1460,7 @@ describe('ReactRelayPaginationContainer', () => {
                 return ref;
             };
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1869,7 +1877,7 @@ describe('ReactRelayPaginationContainer', () => {
 
         it('should not refetch connection if container is unmounted', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -1906,7 +1914,7 @@ describe('ReactRelayPaginationContainer', () => {
 
     const UnwrappedComponent = unwrapContainer(TestUnwrappingContainer);
 
-    const renderer = ReactTestRenderer.create(
+    const renderer = createHooks(
       <UnwrappedComponent user={{id: '4', name: 'Mark'}} />,
     );
 

--- a/__tests__/ReactRelayQueryRenderer-test.tsx
+++ b/__tests__/ReactRelayQueryRenderer-test.tsx
@@ -22,6 +22,14 @@ import * as ReactTestRenderer from 'react-test-renderer';
 
 //import readContext from "react-relay/lib/readContext";
 
+function createHooks(component, options?: any) {
+    const result = ReactTestRenderer.create(component, options);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 import {
     createOperationDescriptor,
     Environment,
@@ -150,7 +158,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     describe('when initialized', () => {
         it('skip', () => {
-            const renderer = ReactTestRenderer.create(
+            const renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         query={TestQuery}
@@ -197,7 +205,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('fetches the query', () => {
-            ReactTestRenderer.create(
+            createHooks(
                 <ReactRelayQueryRenderer
                     query={TestQuery}
                     cacheConfig={cacheConfig}
@@ -216,7 +224,7 @@ describe('ReactRelayQueryRenderer', () => {
                 complete: jest.fn(() => undefined),
                 start: jest.fn(() => undefined),
             };
-            ReactTestRenderer.create(
+            createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         query={TestQuery}
@@ -505,7 +513,7 @@ describe('ReactRelayQueryRenderer', () => {
                             };
                         });
                     });
-                    const renderer = ReactTestRenderer.create(
+                    const renderer = createHooks(
                         <PropsSetter>
                             <ReactRelayQueryRenderer
                                 environment={environment}
@@ -602,7 +610,7 @@ describe('ReactRelayQueryRenderer', () => {
             });
 
             it('fetches the query with default variables', () => {
-                ReactTestRenderer.create(
+                createHooks(
                     <ReactRelayQueryRenderer
                         query={TestQuery}
                         cacheConfig={cacheConfig}
@@ -616,7 +624,7 @@ describe('ReactRelayQueryRenderer', () => {
             });
 
             it('renders with a default ready state', () => {
-                ReactTestRenderer.create(
+                createHooks(
                     <ReactRelayQueryRenderer
                         query={TestQuery}
                         cacheConfig={cacheConfig}
@@ -646,7 +654,7 @@ describe('ReactRelayQueryRenderer', () => {
                     },
                 });
 
-                ReactTestRenderer.create(
+                createHooks(
                     <ReactRelayQueryRenderer
                         query={TestQuery}
                         fetchPolicy="store-and-network"
@@ -681,7 +689,7 @@ describe('ReactRelayQueryRenderer', () => {
                     network: Network.create(fetch),
                     store,
                 });
-                ReactTestRenderer.create(
+                createHooks(
                     <ReactRelayQueryRenderer
                         query={TestQuery}
                         cacheConfig={cacheConfig}
@@ -717,7 +725,7 @@ describe('ReactRelayQueryRenderer', () => {
                     network: Network.create(fetch),
                     store,
                 });
-                ReactTestRenderer.create(
+                createHooks(
                     <ReactRelayQueryRenderer
                         query={TestQuery}
                         cacheConfig={cacheConfig}
@@ -750,7 +758,7 @@ describe('ReactRelayQueryRenderer', () => {
 
       it("sets an environment on context", () => {
         expect.assertions(1);
-        ReactTestRenderer.create(
+        createHooks(
           <ReactRelayQueryRenderer
             environment={environment}
             query={TestQuery}
@@ -765,7 +773,7 @@ describe('ReactRelayQueryRenderer', () => {
 
       it("sets an environment on context with empty query", () => {
         variables = { foo: "bar" };
-        ReactTestRenderer.create(
+        createHooks(
           <ReactRelayQueryRenderer
             environment={environment}
             query={null}
@@ -784,7 +792,7 @@ describe('ReactRelayQueryRenderer', () => {
 
       it("updates the context when the environment changes", () => {
         expect.assertions(2);
-        const renderer = ReactTestRenderer.create(
+        const renderer = createHooks(
           <PropsSetter>
             <ReactRelayQueryRenderer
               environment={environment}
@@ -810,7 +818,7 @@ describe('ReactRelayQueryRenderer', () => {
 
       it("updates the context when the query changes", () => {
         expect.assertions(2);
-        const renderer = ReactTestRenderer.create(
+        const renderer = createHooks(
           <PropsSetter>
             <ReactRelayQueryRenderer
               environment={environment}
@@ -836,7 +844,7 @@ describe('ReactRelayQueryRenderer', () => {
 
       it("updates the context when variables change", () => {
         expect.assertions(5);
-        const renderer = ReactTestRenderer.create(
+        const renderer = createHooks(
           <PropsSetter>
             <ReactRelayQueryRenderer
               environment={environment}
@@ -890,7 +898,7 @@ describe('ReactRelayQueryRenderer', () => {
       it("does not update the context for equivalent variables", () => {
         expect.assertions(2);
         variables = { foo: ["bar"] };
-        const renderer = ReactTestRenderer.create(
+        const renderer = createHooks(
           <PropsSetter>
             <ReactRelayQueryRenderer
               environment={environment}
@@ -921,7 +929,7 @@ describe('ReactRelayQueryRenderer', () => {
             let renderer;
 
             beforeEach(() => {
-                renderer = ReactTestRenderer.create(
+                renderer = createHooks(
                     <PropsSetter>
                         <ReactRelayQueryRenderer
                             environment={environment}
@@ -950,7 +958,7 @@ describe('ReactRelayQueryRenderer', () => {
 
             it('does not update if variables are equivalent', () => {
                 variables = { foo: [1] };
-                renderer = ReactTestRenderer.create(
+                renderer = createHooks(
                     <PropsSetter>
                         <ReactRelayQueryRenderer
                             environment={environment}
@@ -1157,7 +1165,7 @@ describe('ReactRelayQueryRenderer', () => {
                 complete: jest.fn(() => undefined),
                 start: jest.fn(() => undefined),
             };
-            ReactTestRenderer.create(
+            createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1182,7 +1190,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     describe('when the fetch fails', () => {
         beforeEach(() => {
-            ReactTestRenderer.create(
+            createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1277,7 +1285,7 @@ describe('ReactRelayQueryRenderer', () => {
                         );
                     }
                 }
-                const renderer = ReactTestRenderer.create(<Example />);
+                const renderer = createHooks(<Example />);
                 expect.assertions(3);
                 mockA.mockClear();
                 mockB.mockClear();
@@ -1332,7 +1340,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     describe('when the fetch succeeds', () => {
         beforeEach(() => {
-            ReactTestRenderer.create(
+            createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1405,7 +1413,7 @@ describe('ReactRelayQueryRenderer', () => {
       `));
 
             variables = { id: '4' };
-            renderer = ReactTestRenderer.create(
+            renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1505,7 +1513,7 @@ describe('ReactRelayQueryRenderer', () => {
       `));
 
             variables = { id: '4' };
-            renderer = ReactTestRenderer.create(
+            renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1583,7 +1591,7 @@ describe('ReactRelayQueryRenderer', () => {
         }
       `));
 
-            renderer = ReactTestRenderer.create(
+            renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1664,7 +1672,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     describe('when unmounted', () => {
         it('releases its reference if unmounted before fetch completes', () => {
-            const renderer = ReactTestRenderer.create(
+            const renderer = createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1685,7 +1693,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('releases its reference if unmounted after fetch completes', () => {
-            const renderer = ReactTestRenderer.create(
+            const renderer = createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1703,7 +1711,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('aborts a pending fetch', () => {
-            const renderer = ReactTestRenderer.create(
+            const renderer = createHooks(
                 <ReactRelayQueryRenderer
                     environment={environment}
                     query={TestQuery}
@@ -1734,7 +1742,7 @@ describe('ReactRelayQueryRenderer', () => {
         }
       `));
 
-            renderer = ReactTestRenderer.create(
+            renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1788,7 +1796,7 @@ describe('ReactRelayQueryRenderer', () => {
                 throw error;
             });
 
-            ReactTestRenderer.create(
+            createHooks(
                 <ErrorBoundary>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1815,7 +1823,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     describe('When retry', () => {
         it('uses the latest variables after initial render', () => {
-            const renderer = ReactTestRenderer.create(
+            const renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1858,7 +1866,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('observe retry', () => {
-            ReactTestRenderer.create(
+            createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1906,7 +1914,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('skips cache if `force` is set to true', () => {
-            ReactTestRenderer.create(
+            createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1933,7 +1941,7 @@ describe('ReactRelayQueryRenderer', () => {
         });
 
         it('uses cache if `force` is set to false', () => {
-            ReactTestRenderer.create(
+            createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}
@@ -1966,7 +1974,7 @@ describe('ReactRelayQueryRenderer', () => {
         const fetchKey = 'fetchKey';
 
         beforeEach(() => {
-            renderer = ReactTestRenderer.create(
+            renderer = createHooks(
                 <PropsSetter>
                     <ReactRelayQueryRenderer
                         environment={environment}

--- a/__tests__/ReactRelayRefetchContainer-test.tsx
+++ b/__tests__/ReactRelayRefetchContainer-test.tsx
@@ -14,6 +14,14 @@ import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 import { useRefetch, RelayEnvironmentProvider, useRelayEnvironment } from '../src';
 
+function createHooks(component) {
+    const result = ReactTestRenderer.create(component);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 const ReactRelayRefetchContainer = {
     createContainer: (Component, spec, query) => (props) => {
         const { user, ...others } = props;
@@ -186,7 +194,7 @@ describe('ReactRelayRefetchContainer', () => {
   });*/
 
     it('passes non-fragment props to the component', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer bar={1} foo="foo" />
             </ContextSetter>,
@@ -206,7 +214,7 @@ describe('ReactRelayRefetchContainer', () => {
     });
 
     it('passes through null props', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={null} />
             </ContextSetter>,
@@ -225,7 +233,7 @@ describe('ReactRelayRefetchContainer', () => {
     });
 
     it('passes through context', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={null} />
             </ContextSetter>,
@@ -236,7 +244,7 @@ describe('ReactRelayRefetchContainer', () => {
     it('resolves & subscribes fragment props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -269,7 +277,7 @@ describe('ReactRelayRefetchContainer', () => {
     it('re-renders on subscription callback', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -309,7 +317,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     it('resolves new props', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -355,7 +363,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     it('resolves new props when ids dont change', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -402,7 +410,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     it('resolves new props when ids dont change even after it has refetched', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -469,7 +477,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     it('does not update for same props/data', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -493,7 +501,7 @@ describe('ReactRelayRefetchContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} nil={null} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -519,7 +527,7 @@ describe('ReactRelayRefetchContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -552,7 +560,7 @@ describe('ReactRelayRefetchContainer', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -582,7 +590,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     it('always updates for non-scalar props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer arr={[]} obj={{}} user={userPointer} />
             </ContextSetter>,
@@ -622,7 +630,7 @@ describe('ReactRelayRefetchContainer', () => {
             };
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
             environment.mock.clearCache();
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -957,7 +965,7 @@ describe('ReactRelayRefetchContainer', () => {
                 }
             }
 
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainerWrapper />
                 </ContextSetter>,
@@ -985,7 +993,7 @@ describe('ReactRelayRefetchContainer', () => {
 
     const UnwrappedComponent = unwrapContainer(TestUnwrappingContainer);
 
-    const renderer = ReactTestRenderer.create(
+    const renderer = createHooks(
       <UnwrappedComponent user={{ id: "4", name: "Mark" }} />
     );
 

--- a/__tests__/RelayHooks-test.tsx
+++ b/__tests__/RelayHooks-test.tsx
@@ -13,6 +13,14 @@ import {
     useRefetchable,
 } from '../src';
 
+function createHooks(component, options?: any) {
+    const result = ReactTestRenderer.create(component, options);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 describe('useMemo resolver functions', () => {
     let TestComponent;
     let TestContainer;
@@ -182,7 +190,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on subscription callbac', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -211,7 +219,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on change props', () => {
             let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -233,7 +241,7 @@ describe('useMemo resolver functions', () => {
         it('unmount', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -243,7 +251,7 @@ describe('useMemo resolver functions', () => {
             render.mockClear();
 
             instance.unmount();
-            const instance2 = ReactTestRenderer.create(
+            const instance2 = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -280,7 +288,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on subscription callbac', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -309,7 +317,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on change props', () => {
             let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -331,7 +339,7 @@ describe('useMemo resolver functions', () => {
         it('unmount', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -341,7 +349,7 @@ describe('useMemo resolver functions', () => {
             render.mockClear();
 
             instance.unmount();
-            const instance2 = ReactTestRenderer.create(
+            const instance2 = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -378,7 +386,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on subscription callbac', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -407,7 +415,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on change props', () => {
             let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -429,7 +437,7 @@ describe('useMemo resolver functions', () => {
         it('unmount', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -439,7 +447,7 @@ describe('useMemo resolver functions', () => {
             render.mockClear();
 
             instance.unmount();
-            const instance2 = ReactTestRenderer.create(
+            const instance2 = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -476,7 +484,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on subscription callbac', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            ReactTestRenderer.create(
+            createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -505,7 +513,7 @@ describe('useMemo resolver functions', () => {
         it('re-renders on change props', () => {
             let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -527,7 +535,7 @@ describe('useMemo resolver functions', () => {
         it('unmount', () => {
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-            const instance = ReactTestRenderer.create(
+            const instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -537,7 +545,7 @@ describe('useMemo resolver functions', () => {
             render.mockClear();
 
             instance.unmount();
-            const instance2 = ReactTestRenderer.create(
+            const instance2 = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,

--- a/__tests__/useRefetchable-test.tsx
+++ b/__tests__/useRefetchable-test.tsx
@@ -16,6 +16,14 @@ import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 import { useRefetchable, RelayEnvironmentProvider, useRelayEnvironment } from '../src';
 
+function createHooks(component, options?: any) {
+    const result = ReactTestRenderer.create(component, options);
+    ReactTestRenderer.act(() => {
+        jest.runAllImmediates();
+    });
+    return result;
+}
+
 const ReactRelayRefetchContainer = {
     createContainer: (Component, spec, query) => (props) => {
         const { user, ...others } = props;
@@ -193,7 +201,7 @@ describe('useRefetchable', () => {
     });
 
     it('passes non-fragment props to the component', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer bar={1} foo="foo" />
             </ContextSetter>,
@@ -213,7 +221,7 @@ describe('useRefetchable', () => {
     });
 
     it('passes through null props', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={null} />
             </ContextSetter>,
@@ -232,7 +240,7 @@ describe('useRefetchable', () => {
     });
 
     it('passes through context', () => {
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={null} />
             </ContextSetter>,
@@ -243,7 +251,7 @@ describe('useRefetchable', () => {
     it('resolves & subscribes fragment props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -276,7 +284,7 @@ describe('useRefetchable', () => {
     it('re-renders on subscription callback', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
 
-        ReactTestRenderer.create(
+        createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -316,7 +324,7 @@ describe('useRefetchable', () => {
 
     it('resolves new props', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -362,7 +370,7 @@ describe('useRefetchable', () => {
 
     it('resolves new props when ids dont change', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -409,7 +417,7 @@ describe('useRefetchable', () => {
 
     it('resolves new props when ids dont change even after it has refetched', () => {
         let userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -476,7 +484,7 @@ describe('useRefetchable', () => {
 
     it('does not update for same props/data', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer user={userPointer} />
             </ContextSetter>,
@@ -500,7 +508,7 @@ describe('useRefetchable', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} nil={null} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -526,7 +534,7 @@ describe('useRefetchable', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -559,7 +567,7 @@ describe('useRefetchable', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
         const scalar = 42;
         const fn = () => null;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer fn={fn} scalar={scalar} user={userPointer} />
             </ContextSetter>,
@@ -589,7 +597,7 @@ describe('useRefetchable', () => {
 
     it('always updates for non-scalar props', () => {
         const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
-        const instance = ReactTestRenderer.create(
+        const instance = createHooks(
             <ContextSetter environment={environment}>
                 <TestContainer arr={[]} obj={{}} user={userPointer} />
             </ContextSetter>,
@@ -629,7 +637,7 @@ describe('useRefetchable', () => {
             };
             const userPointer = environment.lookup(ownerUser1.fragment, ownerUser1).data.node;
             environment.mock.clearCache();
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainer user={userPointer} />
                 </ContextSetter>,
@@ -964,7 +972,7 @@ describe('useRefetchable', () => {
                 }
             }
 
-            instance = ReactTestRenderer.create(
+            instance = createHooks(
                 <ContextSetter environment={environment}>
                     <TestContainerWrapper />
                 </ContextSetter>,
@@ -992,7 +1000,7 @@ describe('useRefetchable', () => {
 
     const UnwrappedComponent = unwrapContainer(TestUnwrappingContainer);
 
-    const renderer = ReactTestRenderer.create(
+    const renderer = createHooks(
       <UnwrappedComponent user={{ id: "4", name: "Mark" }} />
     );
 

--- a/docs/RelayHooks-Introduction.md
+++ b/docs/RelayHooks-Introduction.md
@@ -44,6 +44,7 @@ After Relay's core team shared information about the the initial differences in 
   * **useQuery**: it is the same as `useLazyLoadQuery` but does not use suspense, it allows you to use hooks without having to migrate the application in concurrent mode and its return is the same as the QueryRenderer HOC
   * **useRefetch**: it is the same as `useRefetchable`, allows you to migrate the Refetch Container without changing the fragment specifications
   * **conditional useQuery & useLazyLoadQuery**: added `skip`: [Optional] If skip is true, the query will be skipped entirely
+  * **observe the execution of the query in the network in useQuery & useLazyLoadQuery**: added `fetchObserver`: [Optional] A fetchObserver can be passed to observe the execution of the query in the network
 
 * why use relay-hooks?
 
@@ -84,6 +85,8 @@ In addition to `query` (first argument) and `variables` (second argument), `useQ
 `networkCacheConfig`: [Optional] Object containing cache config options for the network layer. Note the the network layer may contain an additional query response cache which will reuse network responses for identical queries. If you want to bypass this cache completely, pass {force: true} as the value for this option.
 
 `skip`: [Optional] If skip is true, the query will be skipped entirely.
+
+`fetchObserver`: [Optional] A fetchObserver can be passed to observe the execution of the query in the network
 
 ```ts
 import {useQuery, graphql } from 'relay-hooks';

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,4 +37,5 @@ module.exports = {
         },
     },
     setupFiles: ['./scripts/setup.ts'],
+    timers: 'fake',
 };

--- a/src/QueryFetcher.ts
+++ b/src/QueryFetcher.ts
@@ -255,7 +255,6 @@ export class QueryFetcher<TOperationType extends OperationType = OperationType> 
         // Wait until the first payload to call `onDataChange` and subscribe for data updates.
 
         if (this.snapshot) {
-            observer.next && observer.next(this.snapshot);
             return;
         }
 

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -9,7 +9,11 @@ import {
     MutationConfig as BaseMutationConfig,
     MutationParameters,
 } from 'relay-runtime';
-import { RelayContext, FragmentSpecResolver } from 'relay-runtime/lib/store/RelayStoreTypes';
+import {
+    RelayContext,
+    FragmentSpecResolver,
+    Snapshot,
+} from 'relay-runtime/lib/store/RelayStoreTypes';
 
 export type MutationState<T extends MutationParameters> = {
     loading: boolean;
@@ -48,7 +52,7 @@ export type ContainerResult = {
 export interface RenderProps<T extends OperationType> {
     error: Error | null;
     props: T['response'] | null | undefined;
-    retry: (_cacheConfigOverride?: CacheConfig) => void;
+    retry: (_cacheConfigOverride?: CacheConfig, observer?: Observer<Snapshot>) => void;
     cached?: boolean;
 }
 
@@ -68,6 +72,7 @@ export type QueryOptions = {
     fetchKey?: string | number;
     networkCacheConfig?: CacheConfig;
     skip?: boolean;
+    fetchObserver?: Observer<Snapshot>;
 };
 
 export type $Call<Fn extends (...args: any[]) => any> = Fn extends (arg: any) => infer RT


### PR DESCRIPTION
this PR adds the new option `fetchObserver` in useQuery and useLazyLoadQuery in order to observe the execution of the query in the network. It also adds a new parameter to the retry function to observe its execution. (https://github.com/relay-tools/relay-hooks/issues/103)