### PR TITLE
Exporting LoadQuery & MutationProps types

### DIFF
--- a/src/FragmentResolver.ts
+++ b/src/FragmentResolver.ts
@@ -19,7 +19,12 @@ import {
     __internal,
     ReaderSelector,
 } from 'relay-runtime';
-import { RefetchOptions, PaginationData, ConnectionConfig } from './RelayHooksType';
+import {
+    RefetchOptions,
+    PaginationData,
+    ConnectionConfig,
+    ObserverOrCallback,
+} from './RelayHooksType';
 import {
     isNetworkPolicy,
     isStorePolicy,
@@ -30,8 +35,6 @@ import {
     getNewSelector,
     createOperation,
 } from './Utils';
-
-export type ObserverOrCallback = Observer<void> | ((error: Error) => any);
 
 const { fetchQuery } = __internal;
 

--- a/src/RelayHooksType.ts
+++ b/src/RelayHooksType.ts
@@ -3,6 +3,8 @@ import {
     OperationType,
     CacheConfig,
     GraphQLTaggedNode,
+    Environment,
+    IEnvironment,
     Variables,
     PageInfo,
     Observer,
@@ -32,6 +34,13 @@ export type MutationConfig<T extends MutationParameters> = Partial<
 export type Mutate<T extends MutationParameters> = (
     config?: Partial<MutationConfig<T>>,
 ) => Promise<T['response']>;
+
+export type MutationProps<T extends MutationParameters> = MutationConfig<T> & {
+    children: (mutate: Mutate<T>, state: MutationState<T>) => React.ReactNode;
+    mutation: MutationNode<T>;
+    /** if not provided, the context environment will be used. */
+    environment?: Environment;
+};
 
 export const NETWORK_ONLY = 'network-only';
 export const STORE_THEN_NETWORK = 'store-and-network';
@@ -151,4 +160,16 @@ export type PaginationData = {
     direction: string;
     getConnectionFromProps: Function;
     getFragmentVariables: Function;
+};
+
+export type LoadQuery<TOperationType extends OperationType = OperationType> = {
+    next: (
+        environment: IEnvironment,
+        gqlQuery: GraphQLTaggedNode,
+        variables?: TOperationType['variables'],
+        options?: QueryOptions,
+    ) => Promise<void>;
+    subscribe: (callback: (value: any) => any) => () => void;
+    getValue: (environment?: IEnvironment) => RenderProps<TOperationType> | Promise<any>;
+    dispose: () => void;
 };

--- a/src/loadQuery.ts
+++ b/src/loadQuery.ts
@@ -1,20 +1,8 @@
 import * as areEqual from 'fbjs/lib/areEqual';
 import { GraphQLTaggedNode, OperationType, IEnvironment, isPromise } from 'relay-runtime';
 import { QueryFetcher } from './QueryFetcher';
-import { RenderProps, QueryOptions } from './RelayHooksType';
+import { RenderProps, QueryOptions, LoadQuery } from './RelayHooksType';
 import { createOperation } from './Utils';
-
-export type LoadQuery<TOperationType extends OperationType = OperationType> = {
-    next: (
-        environment: IEnvironment,
-        gqlQuery: GraphQLTaggedNode,
-        variables?: TOperationType['variables'],
-        options?: QueryOptions,
-    ) => Promise<void>;
-    subscribe: (callback: (value: any) => any) => () => void;
-    getValue: (environment?: IEnvironment) => RenderProps<TOperationType> | Promise<any>;
-    dispose: () => void;
-};
 
 const internalLoadQuery = <TOperationType extends OperationType = OperationType>(
     promise = false,

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -4,7 +4,13 @@ import * as React from 'react';
 import { ReactRelayContext } from './ReactRelayContext';
 import { Environment, MutationParameters, commitMutation } from 'relay-runtime';
 import useMounted from '@restart/hooks/useMounted';
-import { MutationNode, MutationConfig, MutationState, Mutate } from './RelayHooksType';
+import {
+    MutationNode,
+    MutationConfig,
+    MutationState,
+    Mutate,
+    MutationProps,
+} from './RelayHooksType';
 const { useCallback, useContext, useState } = React;
 
 export function useMutation<T extends MutationParameters>(
@@ -119,13 +125,6 @@ export function useMutation<T extends MutationParameters>(
 
     return [mutate, state];
 }
-
-export type MutationProps<T extends MutationParameters> = MutationConfig<T> & {
-    children: (mutate: Mutate<T>, state: MutationState<T>) => React.ReactNode;
-    mutation: MutationNode<T>;
-    /** if not provided, the context environment will be used. */
-    environment?: Environment;
-};
 
 export function Mutation<T extends MutationParameters>({
     children,

--- a/src/usePreloadedQuery.ts
+++ b/src/usePreloadedQuery.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { OperationType } from 'relay-runtime';
-import { LoadQuery } from './loadQuery';
-import { RenderProps } from './RelayHooksType';
+import { RenderProps, LoadQuery } from './RelayHooksType';
 import { useRelayEnvironment } from './useRelayEnvironment';
 
 export const usePreloadedQuery = <TOperationType extends OperationType = OperationType>(


### PR DESCRIPTION
This PR moved LoadQuery & MutationProps types to RelayHooksType in order to export them (https://github.com/relay-tools/relay-hooks/issues/105)