### PR TITLE
Split Mutate<T> into MutateWithVariables<T> and MutateWithoutVariables<T> for variables typesafety

### DIFF
--- a/src/RelayHooksTypes.ts
+++ b/src/RelayHooksTypes.ts
@@ -27,8 +27,25 @@ export type MutationConfig<T extends MutationParameters> = Partial<
     onCompleted?(response: T['response']): void;
 };
 
+export type MutationConfigWithoutVariables<T extends MutationParameters> = Omit<
+    MutationConfig<T>,
+    'variables'
+>;
+
+export type MutationConfigWithVariables<T extends MutationParameters> = MutationConfig<T> & {
+    variables: T['variables'];
+};
+
 export type Mutate<T extends MutationParameters> = (
     config?: Partial<MutationConfig<T>>,
+) => Promise<T['response']>;
+
+export type MutateWithVariables<T extends MutationParameters> = (
+    config?: Partial<MutationConfig<T>> & { variables: T['variables'] },
+) => Promise<T['response']>;
+
+export type MutateWithoutVariables<T extends MutationParameters> = (
+    config?: Partial<Omit<MutationConfig<T>, 'variables'>>,
 ) => Promise<T['response']>;
 
 export type MutationProps<T extends MutationParameters> = MutationConfig<T> & {

--- a/src/RelayHooksTypes.ts
+++ b/src/RelayHooksTypes.ts
@@ -3,7 +3,6 @@ import {
     OperationType,
     CacheConfig,
     GraphQLTaggedNode,
-    Environment,
     IEnvironment,
     MutationConfig as BaseMutationConfig,
     MutationParameters,
@@ -41,19 +40,8 @@ export type Mutate<T extends MutationParameters> = (
 ) => Promise<T['response']>;
 
 export type MutateWithVariables<T extends MutationParameters> = (
-    config?: Partial<MutationConfig<T>> & { variables: T['variables'] },
+    config: Partial<MutationConfig<T>> & { variables: T['variables'] },
 ) => Promise<T['response']>;
-
-export type MutateWithoutVariables<T extends MutationParameters> = (
-    config?: Partial<Omit<MutationConfig<T>, 'variables'>>,
-) => Promise<T['response']>;
-
-export type MutationProps<T extends MutationParameters> = MutationConfig<T> & {
-    children: (mutate: Mutate<T>, state: MutationState<T>) => React.ReactNode;
-    mutation: MutationNode<T>;
-    /** if not provided, the context environment will be used. */
-    environment?: Environment;
-};
 
 export const NETWORK_ONLY = 'network-only';
 export const STORE_THEN_NETWORK = 'store-and-network';

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -11,7 +11,6 @@ import {
     MutationState,
     Mutate,
     MutateWithVariables,
-    MutateWithoutVariables,
 } from './RelayHooksTypes';
 import { useRelayEnvironment } from './useRelayEnvironment';
 
@@ -25,10 +24,10 @@ export function useMutation<T extends MutationParameters>(
 ): [MutateWithVariables<T>, MutationState<T>];
 export function useMutation<T extends MutationParameters>(
     mutation: MutationNode<T>,
-    userConfig?: MutationConfigWithVariables<T> ,
+    userConfig?: MutationConfigWithVariables<T>,
     /** if not provided, the context environment will be used. */
     environment?: Environment,
-): [MutateWithoutVariables<T>, MutationState<T>];
+): [Mutate<T>, MutationState<T>];
 export function useMutation<T extends MutationParameters>(
     mutation: MutationNode<T>,
     userConfig: MutationConfig<T> = {},

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -6,13 +6,29 @@ import useMounted from '@restart/hooks/useMounted';
 import {
     MutationNode,
     MutationConfig,
+    MutationConfigWithoutVariables,
+    MutationConfigWithVariables,
     MutationState,
     Mutate,
-    MutationProps,
+    MutateWithVariables,
+    MutateWithoutVariables,
 } from './RelayHooksTypes';
 import { useRelayEnvironment } from './useRelayEnvironment';
+
 const { useCallback, useState } = React;
 
+export function useMutation<T extends MutationParameters>(
+    mutation: MutationNode<T>,
+    userConfig?: MutationConfigWithoutVariables<T>,
+    /** if not provided, the context environment will be used. */
+    environment?: Environment,
+): [MutateWithVariables<T>, MutationState<T>];
+export function useMutation<T extends MutationParameters>(
+    mutation: MutationNode<T>,
+    userConfig?: MutationConfigWithVariables<T> ,
+    /** if not provided, the context environment will be used. */
+    environment?: Environment,
+): [MutateWithoutVariables<T>, MutationState<T>];
 export function useMutation<T extends MutationParameters>(
     mutation: MutationNode<T>,
     userConfig: MutationConfig<T> = {},


### PR DESCRIPTION
#139 

The type names are a bit long, but I felt this was better for clarity.