### PR TITLE
feat: add a skip option for useSubscription

### DIFF
--- a/src/RelayHooksTypes.ts
+++ b/src/RelayHooksTypes.ts
@@ -10,6 +10,7 @@ import {
     VariablesOf,
     FragmentReference,
     RenderPolicy,
+    GraphQLSubscriptionConfig,
 } from 'relay-runtime';
 
 export type MutationState<T extends MutationParameters> = {
@@ -213,4 +214,18 @@ export interface ReturnTypePaginationSuspense<
     errorNext: Error | null;
     errorPrevious: Error | null;
     refetch: RefetchFnDynamic<TQuery, TKey>;
+}
+
+export type SubscriptionConfig = {
+    skip?: boolean;
+};
+
+export type SkipSubscriptionConfig = {
+    skip: true;
+};
+
+export interface SkipGraphQLSubscriptionConfig<TSubscription extends OperationType>
+    extends Omit<GraphQLSubscriptionConfig<TSubscription>, 'variables' | 'subscription'> {
+    subscription?: GraphQLSubscriptionConfig<TSubscription>['subscription'];
+    variables?: TSubscription['variables'];
 }

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -2,10 +2,28 @@ import { useEffect } from 'react';
 import { GraphQLSubscriptionConfig, requestSubscription, OperationType } from 'relay-runtime';
 import { useRelayEnvironment } from './useRelayEnvironment';
 
-type SubscriptionConfig = {
+export type SubscriptionConfig = {
     skip?: boolean;
 };
 
+export type SkipSubscriptionConfig = {
+    skip: true;
+};
+
+export interface SkipGraphQLSubscriptionConfig<TSubscription extends OperationType>
+    extends Omit<GraphQLSubscriptionConfig<TSubscription>, 'variables' | 'subscription'> {
+    subscription?: GraphQLSubscriptionConfig<TSubscription>['subscription'];
+    variables?: TSubscription['variables'];
+}
+
+export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
+    config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
+    opts?: SubscriptionConfig,
+): void;
+export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
+    config: SkipGraphQLSubscriptionConfig<TSubscriptionPayload>,
+    opts: SkipSubscriptionConfig,
+): void;
 export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
     opts?: SubscriptionConfig,

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -2,13 +2,22 @@ import { useEffect } from 'react';
 import { GraphQLSubscriptionConfig, requestSubscription, OperationType } from 'relay-runtime';
 import { useRelayEnvironment } from './useRelayEnvironment';
 
+type SubscriptionConfig = {
+  skip?: boolean;
+}
+
 export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
+    opts?: SubscriptionConfig
 ): void {
     const environment = useRelayEnvironment();
+    const skip = opts?.skip ?? false
 
     useEffect(() => {
+        if (skip) {
+          return
+        }
         const { dispose } = requestSubscription(environment, config);
         return dispose;
-    }, [environment, config]);
+    }, [environment, config, skip]);
 }

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -1,20 +1,11 @@
 import { useEffect } from 'react';
 import { GraphQLSubscriptionConfig, requestSubscription, OperationType } from 'relay-runtime';
+import {
+    SkipGraphQLSubscriptionConfig,
+    SkipSubscriptionConfig,
+    SubscriptionConfig,
+} from './RelayHooksTypes';
 import { useRelayEnvironment } from './useRelayEnvironment';
-
-export type SubscriptionConfig = {
-    skip?: boolean;
-};
-
-export type SkipSubscriptionConfig = {
-    skip: true;
-};
-
-export interface SkipGraphQLSubscriptionConfig<TSubscription extends OperationType>
-    extends Omit<GraphQLSubscriptionConfig<TSubscription>, 'variables' | 'subscription'> {
-    subscription?: GraphQLSubscriptionConfig<TSubscription>['subscription'];
-    variables?: TSubscription['variables'];
-}
 
 export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -3,19 +3,19 @@ import { GraphQLSubscriptionConfig, requestSubscription, OperationType } from 'r
 import { useRelayEnvironment } from './useRelayEnvironment';
 
 type SubscriptionConfig = {
-  skip?: boolean;
-}
+    skip?: boolean;
+};
 
 export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
-    opts?: SubscriptionConfig
+    opts?: SubscriptionConfig,
 ): void {
     const environment = useRelayEnvironment();
-    const skip = opts?.skip ?? false
+    const skip = opts && opts.skip;
 
     useEffect(() => {
         if (skip) {
-          return
+            return;
         }
         const { dispose } = requestSubscription(environment, config);
         return dispose;


### PR DESCRIPTION
Sometimes it is useful to skip a subscription as the variables for setting up the subscription might not be available yet.

Closes https://github.com/relay-tools/relay-hooks/issues/131

Test will follow soon.