### PR TITLE
Removed the MutationConfigWithVariables type as it is not needed

### DIFF
--- a/src/RelayHooksTypes.ts
+++ b/src/RelayHooksTypes.ts
@@ -31,10 +31,6 @@ export type MutationConfigWithoutVariables<T extends MutationParameters> = Omit<
     'variables'
 >;
 
-export type MutationConfigWithVariables<T extends MutationParameters> = MutationConfig<T> & {
-    variables: T['variables'];
-};
-
 export type Mutate<T extends MutationParameters> = (
     config?: Partial<MutationConfig<T>>,
 ) => Promise<T['response']>;

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -6,7 +6,6 @@ import {
     MutationNode,
     MutationConfig,
     MutationConfigWithoutVariables,
-    MutationConfigWithVariables,
     MutationState,
     Mutate,
     MutateWithVariables,
@@ -23,7 +22,7 @@ export function useMutation<T extends MutationParameters>(
 ): [MutateWithVariables<T>, MutationState<T>];
 export function useMutation<T extends MutationParameters>(
     mutation: MutationNode<T>,
-    userConfig?: MutationConfigWithVariables<T>,
+    userConfig?: MutationConfig<T>,
     /** if not provided, the context environment will be used. */
     environment?: Environment,
 ): [Mutate<T>, MutationState<T>];


### PR DESCRIPTION
related: https://github.com/relay-tools/relay-hooks/pull/141

```ts
// good
const [mutate] = useMutation(mutation);
mutate({variables: {}});

// error
const [mutate] = useMutation(mutation);
mutate({});

// good
const [mutate] = useMutation(mutation, {variables: {}});
mutate();

// good
const [mutate] = useMutation(mutation, {variables: {}});
mutate({variables: {}});
```

@andrehsu if you can take a look at this PR  👍 