### PR TITLE
fix skip & dispose fetcher

### DIFF
--- a/src/FetchResolver.ts
+++ b/src/FetchResolver.ts
@@ -80,6 +80,8 @@ export function fetchResolver({
         disposable && disposable.dispose();
         disposeRequest();
         disposable = null;
+        env = null;
+        query = null;
     };
 
     const clearTemporaryRetain = (): void => {


### PR DESCRIPTION
issue: https://github.com/relay-tools/relay-hooks/issues/152

## FetchResolver
* now when the fetcher dispose is requested, the environment and the query are reset so that the fetcher is completely reset.

## QueryFetcher
* memorized the previous skip value in order to correctly manage the rerender
* when the skip is requested, the fetch is skipped and the previous fetch disposed