### PR TITLE
unsubscribe only if the callback function is still subscribed

### DIFF
--- a/__tests__/usePreloadQuery-test.tsx
+++ b/__tests__/usePreloadQuery-test.tsx
@@ -810,5 +810,32 @@ describe('usePreloadQuery', () => {
             TestRenderer.act(() => jest.runAllImmediates());
             expect(callback).not.toBeCalled();
         });
+
+        it('unsubscribe only if the callback function is still subscribed', () => {
+            const callback = jest.fn(() => {});
+            const dispose = prefetched.subscribe(callback);
+            const callbackNew = jest.fn(() => {});
+            // this unsubscribe the first subscription
+            const disposeNew = prefetched.subscribe(callbackNew);
+            dispose(); // do nothing
+            prefetched.next(environment, params, { id: '4' });
+            dataSource.next(response);
+            dataSource.complete();
+            TestRenderer.act(() => jest.runAllImmediates());
+            expect(callback).not.toBeCalled();
+            expect(callbackNew).toBeCalled();
+
+            callbackNew.mockClear();
+            callback.mockClear();
+
+            disposeNew();
+
+            prefetched.next(environment, params, { id: '4' });
+            dataSource.next(response);
+            dataSource.complete();
+            TestRenderer.act(() => jest.runAllImmediates());
+            expect(callback).not.toBeCalled();
+            expect(callbackNew).not.toBeCalled();
+        });
     });
 });

--- a/src/QueryFetcher.ts
+++ b/src/QueryFetcher.ts
@@ -74,6 +74,10 @@ export class QueryFetcher<TOperationType extends OperationType = OperationType> 
         this.cacheConfig = networkCacheConfig;
     }
 
+    getForceUpdate(): () => void {
+        return this.forceUpdate;
+    }
+
     setForceUpdate(forceUpdate): void {
         this.forceUpdate = forceUpdate;
     }

--- a/src/loadQuery.ts
+++ b/src/loadQuery.ts
@@ -3,6 +3,8 @@ import { QueryFetcher } from './QueryFetcher';
 import { RenderProps, QueryOptions, LoadQuery } from './RelayHooksTypes';
 import { forceCache } from './Utils';
 
+const emptyFunction = (): void => undefined;
+
 export const internalLoadQuery = <TOperationType extends OperationType = OperationType>(
     promise = false,
 ): LoadQuery<TOperationType> => {
@@ -10,6 +12,7 @@ export const internalLoadQuery = <TOperationType extends OperationType = Operati
 
     const dispose = (): void => {
         queryFetcher.dispose();
+        queryFetcher.setForceUpdate(emptyFunction);
         queryFetcher = new QueryFetcher<TOperationType>();
     };
 
@@ -40,7 +43,9 @@ export const internalLoadQuery = <TOperationType extends OperationType = Operati
     const subscribe = (callback: () => any): (() => void) => {
         queryFetcher.setForceUpdate(callback);
         return (): void => {
-            queryFetcher.setForceUpdate(() => undefined);
+            if (queryFetcher.getForceUpdate() === callback) {
+                queryFetcher.setForceUpdate(emptyFunction);
+            }
         };
     };
     return {


### PR DESCRIPTION
issue: https://github.com/relay-tools/relay-hooks/issues/151

for version 3.7.0 edit this:
https://github.com/relay-tools/relay-hooks/blob/v3.7.0/src/loadQuery.ts#L99

with
if (listener === callback) {listener = null; }