### PR TITLE
feat: esm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "react",
     "ssr"
   ],
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "module": "./lib/es-relay-hooks.js",
+  "exports": {
+    "import": "./lib/es-relay-hooks.js",
+    "require": "./lib/index.js"
+  },
   "license": "MIT",
   "description": "Relay Hooks",
   "author": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "react",
     "ssr"
   ],
-  "main": "./lib/index.js",
+  "main": "./lib/cjs/cjs-relay-hooks.js",
   "module": "./lib/es-relay-hooks.mjs",
   "exports": {
-    "import": "./lib/es-relay-hooks.mjs",
-    "require": "./lib/index.js"
+    ".": {
+      "import": "./lib/es-relay-hooks.mjs",
+      "require": "./lib/cjs/cjs-relay-hooks.js"
+    },
+    "./package.json": "./package.json"
   },
   "license": "MIT",
   "description": "Relay Hooks",
@@ -26,7 +29,7 @@
   },
   "scripts": {
     "clean": "rimraf lib",
-    "compile": "npm run clean && tsc && npm run build:js && npm run rollup",
+    "compile": "npm run clean && tsc && tsc --project tsconfig.esm.json && npm run build:js && npm run rollup",
     "rollup": "rollup -c",
     "build": "npm run compile && npm run test",
     "test": "cross-env NODE_ENV=test jest --coverage",
@@ -34,7 +37,7 @@
     "format:ci": "prettier --list-different \"src/**/*.{j,t}s*\"",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "prepublishOnly": "npm run build",
-    "build:js": "babel lib --out-dir lib --extensions \".js,.jsx\""
+    "build:js": "babel lib/cjs --out-dir lib/cjs --extensions \".js,.jsx\""
   },
   "dependencies": {
     "fbjs": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "ssr"
   ],
   "main": "./lib/index.js",
-  "module": "./lib/es-relay-hooks.js",
+  "module": "./lib/es-relay-hooks.mjs",
   "exports": {
-    "import": "./lib/es-relay-hooks.js",
+    "import": "./lib/es-relay-hooks.mjs",
     "require": "./lib/index.js"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "build:js": "babel lib --out-dir lib --extensions \".js,.jsx\""
   },
   "dependencies": {
-    "@restart/hooks": "^0.3.1",
     "fbjs": "^3.0.0"
   },
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import replace from '@rollup/plugin-replace';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
+import { promises as fs } from "fs";
 import pkg from './package.json';
 
 const makeExternalPredicate = (externalArr) => {
@@ -24,7 +25,7 @@ function createConfigInternal({ format, production }) {
     return {
         input: 'src/index.ts',
         output: {
-            file: 'lib/' + format + '-relay-hooks' + (production ? '.min' : '') + (format === "es" ? ".mjs" : '.js'),
+            file: 'lib/' + (format === "cjs" ? "cjs/" : "") + format + '-relay-hooks' + (production ? '.min' : '') + '.js',
             format,
             name: 'relay-hooks',
             indent: false,
@@ -82,6 +83,28 @@ function createConfigInternal({ format, production }) {
                     toplevel: format === 'cjs',
                     warnings: true,
                 }),
+            format === "cjs" && {
+                name: "writePkgJSON",
+                writeBundle: async () => {
+                    await fs.writeFile(
+                        "lib/cjs/package.json",
+                        JSON.stringify({
+                            type: "commonjs",
+                        })
+                    );
+                }
+            },
+            format === "es" && {
+                name: "writePkgJSON",
+                writeBundle: async () => {
+                    await fs.writeFile(
+                        "lib/package.json",
+                        JSON.stringify({
+                            type: "module",
+                        })
+                    );
+                }
+            },
         ],
     };
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,6 @@ function createConfigInternal({ format, production }) {
                 'fbjs/lib/areEqual': 'areEqual',
                 'fbjs/lib/invariant': 'invariant',
                 'fbjs/lib/warning': 'warning',
-                '@restart/hooks/useMounted': 'useMounted',
                 react: 'React',
                 'relay-runtime': 'relayRuntime',
             },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ function createConfigInternal({ format, production }) {
     return {
         input: 'src/index.ts',
         output: {
-            file: 'lib/' + format + '-relay-hooks' + (production ? '.min' : '') + '.js',
+            file: 'lib/' + format + '-relay-hooks' + (production ? '.min' : '') + (format === "es" ? ".mjs" : '.js'),
             format,
             name: 'relay-hooks',
             indent: false,

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -39,7 +39,7 @@ export function useMutation<T extends MutationParameters>(
 
     const isMountedRef = React.useRef(true);
     React.useEffect(
-        () => () => {
+        (): (() => void) => (): void => {
             isMountedRef.current = false;
         },
         [],

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -1,4 +1,3 @@
-import useMounted from '@restart/hooks/useMounted';
 import * as invariant from 'fbjs/lib/invariant';
 import * as React from 'react';
 import { Environment, MutationParameters, commitMutation } from 'relay-runtime';
@@ -38,7 +37,13 @@ export function useMutation<T extends MutationParameters>(
         error: null,
     });
 
-    const isMounted = useMounted();
+    const isMountedRef = React.useRef(true);
+    React.useEffect(
+        () => () => {
+            isMountedRef.current = false;
+        },
+        [],
+    );
 
     const relayEnvironment = useRelayEnvironment();
     const resolvedEnvironment = environment || relayEnvironment;
@@ -69,7 +74,7 @@ export function useMutation<T extends MutationParameters>(
 
             invariant(mergedConfig.variables, 'you must specify variables');
 
-            if (isMounted()) {
+            if (isMountedRef.current) {
                 setState({
                     loading: true,
                     data: mergedConfig.optimisticResponse,
@@ -79,7 +84,7 @@ export function useMutation<T extends MutationParameters>(
 
             return new Promise((resolve, reject) => {
                 function handleError(error: any): void {
-                    if (isMounted()) {
+                    if (isMountedRef.current) {
                         setState({
                             loading: false,
                             data: null,
@@ -106,7 +111,7 @@ export function useMutation<T extends MutationParameters>(
                             return;
                         }
 
-                        if (isMounted()) {
+                        if (isMountedRef.current) {
                             setState({
                                 loading: false,
                                 data: response,
@@ -134,7 +139,6 @@ export function useMutation<T extends MutationParameters>(
             optimisticUpdater,
             optimisticResponse,
             updater,
-            isMounted,
         ],
     );
 

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "outDir": "lib/cjs",
+    "outDir": "lib",
     "rootDir": "src",
-    "module": "commonjs",
-    "target": "es5",
+    "module": "ESNext",
+    "target": "ES2020",
     "moduleResolution": "node",
     "noEmitOnError": true,
-    "declaration": false,
+    "declaration": true,
     "lib": ["dom", "es6", "esnext.asynciterable", "es2017.object"],
     "jsx": "react",
     "skipLibCheck": true


### PR DESCRIPTION
I noticed that the esm version was broken due to @restart/hooks not being esm compatible and the es module export entry in the package.json missing.

I removed the @restart/hooks dependency in favor of a simply inline of the logic and also adjusted the package.json for the es export.

With those changes, relay-hooks can be successfully used with snowpack.