### PR TITLE
update relay dependencies (v11.0.0)

### DIFF
--- a/__tests__/ReactRelayFragmentContainer-test.tsx
+++ b/__tests__/ReactRelayFragmentContainer-test.tsx
@@ -56,11 +56,9 @@ const ReactRelayQueryRenderer = (props) => (
 );
 
 const { createReaderSelector, createOperationDescriptor } = require('relay-runtime');
-const {
-    createMockEnvironment,
-    generateAndCompile,
-    unwrapContainer,
-} = require('relay-test-utils-internal');
+const { createMockEnvironment } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 
 describe('ReactRelayFragmentContainer', () => {
     let TestComponent;

--- a/__tests__/ReactRelayPaginationContainer-test.tsx
+++ b/__tests__/ReactRelayPaginationContainer-test.tsx
@@ -14,12 +14,7 @@
 
 import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
-import {
-    usePagination,
-    RelayEnvironmentProvider,
-    useRelayEnvironment,
-    RefetchOptions,
-} from '../src';
+import { usePagination, RelayEnvironmentProvider, useRelayEnvironment } from '../src';
 import { forceCache } from '../src/Utils';
 
 function createHooks(component, options?: any) {
@@ -44,7 +39,7 @@ const ReactRelayPaginationContainer = {
             refetch: refetchConnectionHooks,
             errorNext,
         } = dataPag;
-        const loadMore = (count, callback: (error: Error) => void, options?: RefetchOptions) => {
+        const loadMore = (count, callback: (error: Error) => void, options?: any) => {
             // @ts-ignore
             return loadMoreHooks(count, {
                 onComplete: callback,
@@ -83,11 +78,9 @@ const {
     ConnectionHandler,
     ConnectionInterface,
 } = require('relay-runtime');
-const {
-    createMockEnvironment,
-    generateAndCompile,
-    unwrapContainer,
-} = require('relay-test-utils-internal');
+const { createMockEnvironment } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 
 describe('ReactRelayPaginationContainer', () => {
     let TestComponent;

--- a/__tests__/ReactRelayQueryRenderer-test.tsx
+++ b/__tests__/ReactRelayQueryRenderer-test.tsx
@@ -40,7 +40,9 @@ import {
     ROOT_ID,
 } from 'relay-runtime';
 import { ROOT_TYPE } from 'relay-runtime/lib/store/RelayStoreUtils';
-import { createMockEnvironment, generateAndCompile, simpleClone } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+
+const { generateAndCompile } = require('./TestCompiler');
 /*
 function expectToBeRendered(renderFn, readyState) {
   // Ensure useEffect is called before other timers

--- a/__tests__/ReactRelayRefetchContainer-test.tsx
+++ b/__tests__/ReactRelayRefetchContainer-test.tsx
@@ -50,11 +50,9 @@ const ReactRelayRefetchContainer = {
 };
 
 const { createReaderSelector, createOperationDescriptor } = require('relay-runtime');
-const {
-    createMockEnvironment,
-    generateAndCompile,
-    unwrapContainer,
-} = require('relay-test-utils-internal');
+const { createMockEnvironment } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 
 describe('ReactRelayRefetchContainer', () => {
     let TestComponent;

--- a/__tests__/RelayHooks-test.tsx
+++ b/__tests__/RelayHooks-test.tsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 
 import { createOperationDescriptor } from 'relay-runtime';
-import { createMockEnvironment, generateAndCompile } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+
+const { generateAndCompile } = require('./TestCompiler');
 import {
     useOssFragment,
     RelayEnvironmentProvider,

--- a/__tests__/TestCompiler.ts
+++ b/__tests__/TestCompiler.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+import { TestSchema, parseGraphQLText } from 'relay-test-utils-internal';
+
+import { CodeMarker, CompilerContext, IRTransforms, compileRelayArtifacts } from 'relay-compiler';
+import { GeneratedNode } from 'relay-runtime';
+
+/**
+ * Parses GraphQL text, applies the selected transforms only (or none if
+ * transforms is not specified), and returns a mapping of definition name to
+ * its basic generated representation.
+ */
+export function generateWithTransforms(
+    text: string,
+    transforms?: Array<any> | null,
+): { [key: string]: GeneratedNode } {
+    return generate(
+        text,
+        TestSchema,
+        {
+            commonTransforms: transforms || [],
+            fragmentTransforms: [],
+            queryTransforms: [],
+            codegenTransforms: [],
+            printTransforms: [],
+        },
+        null,
+    );
+}
+
+/**
+ * Compiles the given GraphQL text using the standard set of transforms (as
+ * defined in RelayCompiler) and returns a mapping of definition name to
+ * its full runtime representation.
+ */
+export function generateAndCompile(
+    text: string,
+    schema?: any | null,
+    moduleMap?: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    return generate(text, schema ?? TestSchema, IRTransforms, moduleMap ?? null);
+}
+
+function generate(
+    text: string,
+    schema: any,
+    transforms: any,
+    moduleMap: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    const relaySchema = schema.extend(IRTransforms.schemaExtensions);
+    const { definitions, schema: extendedSchema } = parseGraphQLText(relaySchema, text);
+    const compilerContext = new CompilerContext(extendedSchema).addAll(definitions);
+    const documentMap = {};
+    compileRelayArtifacts(compilerContext, transforms).forEach(([_definition, node]) => {
+        const transformedNode = moduleMap != null ? CodeMarker.transform(node, moduleMap) : node;
+        documentMap[node.kind === 'Request' ? node.params.name : node.name] = transformedNode;
+    });
+    return documentMap;
+}

--- a/__tests__/useFragment-test.tsx
+++ b/__tests__/useFragment-test.tsx
@@ -156,7 +156,9 @@ beforeEach(() => {
     }));
     renderSpy = jest.fn();
 
-    ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+    ({ generateAndCompile } = require('./TestCompiler'));
+
+    ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/__tests__/useFragmentNode-test.tsx
+++ b/__tests__/useFragmentNode-test.tsx
@@ -27,7 +27,6 @@ jest.mock('fbjs/lib/warning', () => {
     return f;
 });
 
-
 let mockGetPromise = false;
 jest.doMock('relay-runtime', () => {
     const originalRuntime = jest.requireActual('relay-runtime');
@@ -159,7 +158,9 @@ beforeEach(() => {
     //(Scheduler as any).mockClear();
     renderSpy = jest.fn();
 
-    ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+    ({ generateAndCompile } = require('./TestCompiler'));
+
+    ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
     // Set up environment and base data
     environment = createMockEnvironment();
@@ -1074,7 +1075,7 @@ it('should throw a promise if if data is missing for fragment and request is in 
         'getPromiseForActiveRequest',
     ).mockImplementationOnce(() => Promise.resolve());*/
     mockGetPromise = true;
-    
+
     const missingDataVariables = { ...singularVariables, id: '4' };
     const missingDataQuery = createOperationDescriptor(gqlSingularQuery, missingDataVariables);
     // Commit a payload with name and profile_picture are missing

--- a/__tests__/useFragmentNodeRequired-test.tsx
+++ b/__tests__/useFragmentNodeRequired-test.tsx
@@ -30,7 +30,9 @@ import {
 } from 'relay-runtime';
 
 (RelayFeatureFlags as any).ENABLE_REQUIRED_DIRECTIVES = true;
-import { createMockEnvironment, generateAndCompile } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+
+const { generateAndCompile } = require('./TestCompiler');
 
 //import * as Scheduler from 'scheduler';
 import { ReactRelayContext, useSuspenseFragment as useFragmentNodeOriginal } from '../src';

--- a/__tests__/useLazyLoadQueryNode-test.tsx
+++ b/__tests__/useLazyLoadQueryNode-test.tsx
@@ -15,6 +15,7 @@
 
 import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
+import { RecordSource, Store } from 'relay-runtime';
 
 import { useLazyLoadQuery as useLazyLoadQueryNode, RelayEnvironmentProvider } from '../src';
 
@@ -71,7 +72,9 @@ describe('useLazyLoadQueryNode', () => {
             isServer: false,
         }));*/
 
-        ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+        ({ generateAndCompile } = require('./TestCompiler'));
+
+        ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
         class ErrorBoundary extends React.Component<any, any> {
             state = { error: null };
@@ -122,7 +125,9 @@ describe('useLazyLoadQueryNode', () => {
             );
         };
 
-        environment = createMockEnvironment();
+        environment = createMockEnvironment({
+            store: new Store(new RecordSource(), { gcReleaseBufferSize: 0 }),
+        });
         release = jest.fn();
         const originalRetain = environment.retain.bind(environment);
         // $FlowFixMe

--- a/__tests__/useMutation-test.tsx
+++ b/__tests__/useMutation-test.tsx
@@ -17,7 +17,9 @@ import * as React from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 
 import { createOperationDescriptor, PayloadData, PayloadError } from 'relay-runtime';
-import { createMockEnvironment, generateAndCompile } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+
+const { generateAndCompile } = require('./TestCompiler');
 import { useMutation, RelayEnvironmentProvider } from '../src';
 
 const { useState, useMemo } = React;

--- a/__tests__/usePaginationFragment-test.tsx
+++ b/__tests__/usePaginationFragment-test.tsx
@@ -180,7 +180,9 @@ describe('usePaginationFragment', () => {
         jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
         renderSpy = jest.fn();
 
-        ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+        ({ generateAndCompile } = require('./TestCompiler'));
+
+        ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
         // Set up environment and base data
         environment = createMockEnvironment({

--- a/__tests__/usePreloadQuery-test.tsx
+++ b/__tests__/usePreloadQuery-test.tsx
@@ -20,7 +20,9 @@ import * as React from 'react';
 import * as TestRenderer from 'react-test-renderer';
 
 import { Environment, Network, Observable, RecordSource, Store } from 'relay-runtime';
-import { createMockEnvironment, generateAndCompile } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+
+const { generateAndCompile } = require('./TestCompiler');
 import { usePreloadedQuery, loadQuery, loadLazyQuery, RelayEnvironmentProvider } from '../src';
 
 const query = generateAndCompile(`

--- a/__tests__/useRefetchable-test.tsx
+++ b/__tests__/useRefetchable-test.tsx
@@ -50,11 +50,9 @@ const ReactRelayRefetchContainer = {
 };
 
 const { createReaderSelector, createOperationDescriptor } = require('relay-runtime');
-const {
-    createMockEnvironment,
-    generateAndCompile,
-    unwrapContainer,
-} = require('relay-test-utils-internal');
+const { createMockEnvironment } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 
 describe('useRefetchable', () => {
     let TestComponent;

--- a/__tests__/useRefetchableFragment-test.tsx
+++ b/__tests__/useRefetchableFragment-test.tsx
@@ -177,7 +177,9 @@ describe('useRefetchableFragmentNode', () => {
         fetchPolicy = 'store-or-network';
         renderPolicy = 'partial';
 
-        ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+        ({ generateAndCompile } = require('./TestCompiler'));
+
+        ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
         // Set up environment and base data
         environment = createMockEnvironment();
@@ -491,7 +493,9 @@ describe('useRefetchableFragmentNode', () => {
 
         beforeEach(() => {
             jest.resetModules();
-            ({ createMockEnvironment, generateAndCompile } = require('relay-test-utils-internal'));
+
+            ({ generateAndCompile } = require('./TestCompiler'));
+            ({ createMockEnvironment } = require('relay-test-utils-internal'));
 
             release = jest.fn();
             environment.retain.mockImplementation((...args) => {

--- a/__tests__/useSubscription-test.tsx
+++ b/__tests__/useSubscription-test.tsx
@@ -16,7 +16,8 @@ import { useMemo, useState } from 'react';
 import * as ReactTestRenderer from 'react-test-renderer';
 import { Environment } from 'relay-runtime';
 
-import { createMockEnvironment, generateAndCompile } from 'relay-test-utils-internal';
+import { createMockEnvironment } from 'relay-test-utils-internal';
+const { generateAndCompile } = require('./TestCompiler');
 import { RelayEnvironmentProvider } from '../src';
 
 const dispose = jest.fn();
@@ -55,9 +56,7 @@ describe('useSubscription', () => {
 
     const { useSubscription } = require('../src');
 
-    const ContextProvider = ({ children }: {
-        children: React.ReactNode
-    }) => {
+    const ContextProvider = ({ children }: { children: React.ReactNode }) => {
         const [env, _setEnv] = useState(mockEnv);
         const relayContext = useMemo(() => ({ environment: env }), [env]);
 
@@ -77,9 +76,9 @@ describe('useSubscription', () => {
         jest.resetAllMocks();
     });
 
-    function MyComponent(props: { env: Environment, skip?: boolean; }): React.ReactElement {
+    function MyComponent(props: { env: Environment; skip?: boolean }): React.ReactElement {
         function InnerComponent(): React.ReactElement {
-            useSubscription(config,  { skip: props.skip });
+            useSubscription(config, { skip: props.skip });
             return <>Hello Relay!</>;
         }
         return (
@@ -90,9 +89,11 @@ describe('useSubscription', () => {
     }
 
     let componentInstance;
-    const renderComponent = (props?: { skip: boolean; }) =>
+    const renderComponent = (props?: { skip: boolean }) =>
         ReactTestRenderer.act(() => {
-            componentInstance = ReactTestRenderer.create(<MyComponent env={mockEnv} skip={props?.skip || false} />);
+            componentInstance = ReactTestRenderer.create(
+                <MyComponent env={mockEnv} skip={props?.skip || false} />,
+            );
         });
 
     it('should call requestSubscription when mounted', () => {
@@ -137,7 +138,7 @@ describe('useSubscription', () => {
         expect(dispose).not.toHaveBeenCalled();
     });
 
-    it("should subscribe when skip option is set to false", () => {
+    it('should subscribe when skip option is set to false', () => {
         renderComponent({ skip: false });
         expect(requestSubscription).toHaveBeenCalledTimes(1);
         expect(dispose).not.toHaveBeenCalled();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,12 +1694,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
@@ -5042,9 +5042,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -11899,9 +11899,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     },
     "regex-not": {
@@ -11993,9 +11993,9 @@
       "dev": true
     },
     "relay-compiler": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-10.1.0.tgz",
-      "integrity": "sha512-HPqc3N3tNgEgUH5+lTr5lnLbgnsZMt+MRiyS0uAVNhuPY2It0X1ZJG+9qdA3L9IqKFUNwVn6zTO7RArjMZbARQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-11.0.0.tgz",
+      "integrity": "sha512-xAVcnWBNtkIJqRwae2agY+riDhh00bV/HqwbcBYijK/S9jKPEFLx9FguGG1V8EWgS/barBsBMtE7CG916GtSrA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
@@ -12011,7 +12011,7 @@
         "glob": "^7.1.1",
         "immutable": "~3.7.6",
         "nullthrows": "^1.1.1",
-        "relay-runtime": "10.1.0",
+        "relay-runtime": "11.0.0",
         "signedsource": "^1.0.0",
         "yargs": "^15.3.1"
       },
@@ -12050,21 +12050,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "dev": true,
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -12083,87 +12068,36 @@
       }
     },
     "relay-runtime": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-10.1.0.tgz",
-      "integrity": "sha512-bxznLnQ1ST6APN/cFi7l0FpjbZVchWQjjhj9mAuJBuUqNNCh9uV+UTRhpQF7Q8ycsPp19LHTpVyGhYb0ustuRQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-11.0.0.tgz",
+      "integrity": "sha512-7oeyW4hulyK3p4eB63Rsllo/es83xflCAt2HMWCpH2q0fi21iJBR02kK3wCPM/yFwi3i0K83W+UksLFQdE0CaQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.0"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "dev": true,
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
       }
     },
     "relay-test-utils": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-test-utils/-/relay-test-utils-10.1.0.tgz",
-      "integrity": "sha512-2EDrssIx4UEHoktgIhgTcJtavP0mhh4V2r4r60WIDk4kvNwzvsbV9kdGHanYg/1tniVoA6wJT3MyaV6C12c92w==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/relay-test-utils/-/relay-test-utils-11.0.0.tgz",
+      "integrity": "sha512-DhIgIfwwqQy4mOM7bJ6FhJycHsHfvc6mYA0+pr+T93LdB1xUdRKXhm87QyIxKJpGipfhfAGf3r3jxMJWdqlZrA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.0",
-        "relay-runtime": "10.1.0"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "dev": true,
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
+        "relay-runtime": "11.0.0"
       }
     },
     "relay-test-utils-internal": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-test-utils-internal/-/relay-test-utils-internal-10.1.0.tgz",
-      "integrity": "sha512-SElLlpCPXdHh0/j0xoq0V+rHQfYriSQbBlTubFpX8fNLVJ3Z4+9JYdyT60AaWtYc2NMTp3XCMG6qaz7X59RN4A==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/relay-test-utils-internal/-/relay-test-utils-internal-11.0.0.tgz",
+      "integrity": "sha512-Vn0zX2g5eS5R42S4Ntd5H5xvSWJvB0PDR4B4BC2+nmIWOOLqqldc4KNBS3y3eebZ1ZwwyvAFsF+KgnE7GCTG3g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "fbjs": "^3.0.0",
-        "relay-compiler": "10.1.0",
-        "relay-runtime": "10.1.0"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "dev": true,
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
+        "relay-compiler": "11.0.0",
+        "relay-runtime": "11.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -14322,9 +14256,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -14474,9 +14408,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yargs": {
@@ -14566,9 +14500,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
   },
   "peerDependencies": {
     "react": "^16.9.0 || ^17",
-    "relay-runtime": ">=10.1.0"
+    "relay-runtime": ">=10.1.0 || >=11.0.0"
   },
   "devDependencies": {
     "babel-preset-fbjs": "^3.3.0",
     "@babel/cli": "^7.8.3",
+    "@babel/runtime": "7.12.5",
     "@rollup/plugin-commonjs": "14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",
@@ -72,9 +73,9 @@
     "promise-polyfill": "6.1.0",
     "react": "16.11.0",
     "react-test-renderer": "16.11.0",
-    "relay-runtime": "^10.1.0",
-    "relay-test-utils": "10.1.0",
-    "relay-test-utils-internal": "10.1.0",
+    "relay-runtime": "^11.0.0",
+    "relay-test-utils": "^11.0.0",
+    "relay-test-utils-internal": "^11.0.0",
     "rimraf": "^2.5.4",
     "rollup": "^2.23.0",
     "rollup-plugin-sourcemaps": "0.6.2",


### PR DESCRIPTION
* update relay dependencies
* Restored the TestCompiler file deleted in relay-test-utils-internal 
  * With this commit https://github.com/facebook/relay/commit/7ca4ce748d5bf4aafe7943a961713cf66b092406 TestCompiler has been removed in favor of the use of the new rust compiler. At the moment I preferred to restore the TestCompiler in this repository and evaluate in the future if it will be necessary to integrate the compiler in Rust
* update all tests in order to use internal TestCompiler

Currently relay-hooks v4 is perfectly compatible with relay-runtime v11. https://github.com/relay-tools/relay-hooks/issues/164

Obviously it is recommended to read [the relay release notes v11.0.0](https://github.com/facebook/relay/releases/tag/v11.0.0) in order to adapt the applications to the released breaking changes (eg gcReleaseBufferSize)  