### PR TITLE
poc: transient fragment for by-passing re-renders

### DIFF
--- a/__tests__/useFragment-test.tsx
+++ b/__tests__/useFragment-test.tsx
@@ -12,9 +12,9 @@
 /* eslint-disable */
 
 import * as React from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import * as TestRenderer from 'react-test-renderer';
-import { useFragment as useFragmentNodeOriginal, ReactRelayContext } from '../src';
+import { useFragment as useFragmentNodeOriginal, useTransientFragment, ReactRelayContext } from '../src';
 import {
     FRAGMENT_OWNER_KEY,
     FRAGMENTS_KEY,
@@ -95,6 +95,7 @@ let pluralVariables;
 let setEnvironment;
 let setSingularOwner;
 let renderSingularFragment;
+let subscribeSingularFragment;
 let renderPluralFragment;
 let forceSingularUpdate;
 let renderSpy;
@@ -258,6 +259,24 @@ beforeEach(() => {
         return <SingularRenderer user={userData} />;
     };
 
+    const SingularSubscribeContainer = (props) => {
+      const [owner, _setOwner] = useState(props.owner);
+      const [, _setCount] = useState(0);
+      const userRef = props.hasOwnProperty('userRef')
+          ? props.userRef
+          : {
+                [ID_KEY]: owner.request.variables.id,
+                [FRAGMENTS_KEY]: {
+                    UserFragment: {},
+                },
+                [FRAGMENT_OWNER_KEY]: owner.request,
+            };
+
+      setSingularOwner = _setOwner;
+      useTransientFragment(gqlSingularFragment, userRef, props.onData)
+      return null
+    }
+
     const PluralContainer = (props) => {
         // We need a render a component to run a Hook
         const owner = props.owner;
@@ -309,6 +328,17 @@ beforeEach(() => {
             { unstable_isConcurrent: isConcurrent },
         );
     };
+
+    subscribeSingularFragment = (props) => {
+      return TestRenderer.create(
+        <React.Suspense fallback="Singular Fallback">
+            <ContextProvider>
+                <SingularSubscribeContainer owner={singularQuery} {...props} />
+            </ContextProvider>
+        </React.Suspense>,
+        { unstable_isConcurrent: false },
+    );
+    }
 });
 
 afterEach(() => {
@@ -1345,3 +1375,89 @@ describe("disableStoreUpdates", () => {
   });
 });
 */
+
+
+it('should invoke singular subscribe handler without error when data is available', (done) => {
+  subscribeSingularFragment({ onData: (data) => {
+    expect(data).toEqual({
+      id: '1',
+      name: 'Alice',
+      profile_picture: null,
+      ...createFragmentRef('1', singularQuery),
+    })
+    done()
+  }})
+  assertFragmentResults([])
+})
+
+it('should invoke singular subscribe handler when fragment data changes again', (done) => {
+  let counter = 0
+  subscribeSingularFragment({ onData: (data) => {
+    counter = counter + 1
+    if (counter === 1) {
+      expect(data).toEqual({
+        id: '1',
+        name: 'Alice',
+        profile_picture: null,
+        ...createFragmentRef('1', singularQuery),
+      })
+    } else if (counter === 2) {
+      expect(data).toEqual({
+        id: '1',
+        // Assert that name is updated
+        name: 'Alice in Wonderland',
+        profile_picture: null,
+        ...createFragmentRef('1', singularQuery),
+      })
+      done()
+    } else {
+      done.fail("More invocations that expected")
+    }
+  }});
+  assertFragmentResults([])
+  TestRenderer.act(() => {
+      environment.commitPayload(singularQuery, {
+          node: {
+              __typename: 'User',
+              id: '1',
+              // Update name
+              name: 'Alice in Wonderland',
+          },
+      });
+  });
+  assertFragmentResults([])
+});
+
+it('should invoke singular subscribe handler when fragment params changes', (done) => {
+  let counter = 0
+  const newOwner = createOperationDescriptor(gqlSingularQuery, {...singularVariables, id: '2'});
+
+  subscribeSingularFragment({ onData: (data) => {
+    counter = counter + 1
+    if (counter === 1) {
+      expect(data).toEqual({
+        id: '1',
+        name: 'Alice',
+        profile_picture: null,
+        ...createFragmentRef('1', singularQuery),
+      })
+    } else if (counter === 2) {
+      expect(data).toEqual({
+        id: '2',
+        // Assert that name is updated
+        name: 'Bob',
+        profile_picture: null,
+        ...createFragmentRef('2', newOwner),
+      })
+      done()
+    } else {
+      done.fail("More invocations that expected")
+    }
+  }});
+  assertFragmentResults([])
+
+  TestRenderer.act(() => {
+    setSingularOwner(newOwner);
+  });
+  assertFragmentResults([])
+})

--- a/docs/useFragment.md
+++ b/docs/useFragment.md
@@ -49,3 +49,46 @@ import { useSuspenseFragment } from 'relay-hooks';
 ```
 
 [See useFragment](https://relay.dev/docs/en/api-reference#usefragment)
+
+# useTransientFragment
+
+Instead of `useFragment` the `useTransientFragment` takes a callback that is always invoked with the latest fragment data. This can be useful when dealing with components where a re-render is expensive. 
+
+## Arguments:
+
+  * `fragment`: GraphQL fragment specified using a graphql template literal.
+  * `fragmentReference`: The fragment reference is an opaque Relay object that Relay uses to read the data for the fragment from the store; more specifically, it contains information about which particular object instance the data should be read from. 
+    * The type of the fragment reference can be imported from the generated Flow types, from the file `<fragment_name>.graphql.js`, and can be used to declare the type of your `Props`. The name of the fragment reference type will be: `<fragment_name>$key`. We use our [lint rule](https://github.com/relayjs/eslint-plugin-relay) to enforce that the type of the fragment reference prop is correctly declared.
+  * `onFragmentData`: A callback that will be invoked with the latest fragment data.
+
+## Return Value:
+
+  * `void`: This hook returns no value
+
+```ts
+import * as React from 'react';
+import { useTransientFragment, graphql } from 'relay-hooks';
+
+const fragmentSpec = graphql`
+    fragment TodoApp_user on User {
+      id
+      userId
+      totalCount
+    }
+  `;
+
+const TodoApp = (props) => {
+    const ref = React.useRef()
+    const user = useTransientFragment(
+        fragmentSpec,
+        props.user,
+        React.useCallback((user) => {
+            ref.current.updateUserInformation(user);
+        }, [])
+    );
+    return (
+        <SomeExpensiveComponent ref={ref} />
+    );
+};
+```
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { ReactRelayContext } from './ReactRelayContext';
 export { useQuery, useLazyLoadQuery } from './useQuery';
 export { loadQuery, loadLazyQuery } from './loadQuery';
 export { usePreloadedQuery } from './usePreloadedQuery';
-export { useFragment, useSuspenseFragment } from './useFragment';
+export { useFragment, useSuspenseFragment, useTransientFragment } from './useFragment';
 export { useMutation } from './useMutation';
 export { useSubscription } from './useSubscription';
 export { useOssFragment } from './useOssFragment';

--- a/src/useFragment.tsx
+++ b/src/useFragment.tsx
@@ -48,3 +48,26 @@ export function useSuspenseFragment<TKey extends ArrayKeyType>(
     const [data] = useOssFragment(fragmentNode, fragmentRef, true, FRAGMENT_NAME);
     return data;
 }
+
+export function useTransientFragment<TKey extends KeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey,
+    callback: (data: $Call<KeyReturnType<TKey>>) => void,
+): void;
+export function useTransientFragment<TKey extends KeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+    callback: (data: $Call<KeyReturnType<TKey>> | null) => void,
+): void;
+export function useTransientFragment<TKey extends ArrayKeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey,
+    callback: (data: ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>) => void,
+): void;
+export function useTransientFragment<TKey extends ArrayKeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+    callback: (data: ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>) => void,
+): void {
+    useOssFragment(fragmentNode, fragmentRef, false, FRAGMENT_NAME, callback);
+}

--- a/src/useOssFragment.tsx
+++ b/src/useOssFragment.tsx
@@ -60,7 +60,7 @@ export function useOssFragment(
             const data = resolver.getData();
             subscribe(data);
         }
-    }, [subscribe, idfragment]);
+    }, [subscribe, resolver, idfragment]);
 
     useEffect(() => {
         next();


### PR DESCRIPTION
I have the need for subscribing to a fragment in a performant way in order to sync it with some not directly react related store. Doing that with `useFragment` and `React.useEffect` is not performant enough as the value updates quite frequently. For this use-case it would be beneficial to bypass re-renders and directly invoke some callback with the latest fragment data.

The naming is debatable. It seems that in the react-three-fiber community by-passing render state is usually described as transient updates. I am happy to choose any other naming though. E.g. `useFragmentSubscription`, `useSubscriptionFragment`.

I originally posted the idea in the GraphQL Slack: https://graphql.slack.com/archives/C0BEXJLKG/p1618139127305000

@morrys  Please let me know how you think about this addition 😇  