### PR TITLE
Esm supports

### DIFF
--- a/examples/relay-hook-example/cra/package.json
+++ b/examples/relay-hook-example/cra/package.json
@@ -6,14 +6,14 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "babel-plugin-relay": "10.1.2",
+    "babel-plugin-relay": "11.0.2",
     "graphql": "^14.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "relay-compiler": "^10.1.2",
-    "relay-hooks": "4.0.0",
-    "relay-runtime": "10.1.2"
+    "relay-compiler": "^11.0.2",
+    "relay-hooks": "4.2.0",
+    "relay-runtime": "11.0.2"
   }, 
   "devDependencies": {
     "apollo-server-express": "2.11.0"

--- a/examples/relay-hook-example/pagination-nextjs-ssr/package.json
+++ b/examples/relay-hook-example/pagination-nextjs-ssr/package.json
@@ -18,7 +18,7 @@
     "es6-promise": "4.2.8",
     "express": "^4.16.4",
     "express-graphql": "^0.7.1",
-    "graphql": "^14.5.8",
+    "graphql": "^15.5.0",
     "graphql-relay": "^0.6.0",
     "isomorphic-unfetch": "3.0.0",
     "isomorphic-fetch": "^2.1.1",
@@ -26,8 +26,8 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "relay-hooks": "4.0.0",
-    "relay-runtime": "^10.1.0",
+    "relay-hooks": "4.2.0",
+    "relay-runtime": "11.0.2",
     "whatwg-fetch": "3.0.0",
     "react-infinite-scroller": "1.2.4"
   },
@@ -42,13 +42,13 @@
     "@types/node": "^12.7.12",
     "@types/react": "^17.0.0",
     "@types/react-relay": "^7.0.2",
-    "@types/relay-runtime": "^10.1.3",
+    "@types/relay-runtime": "11.0.0",
     "@zeit/next-typescript": "1.1.1",
     "babel-loader": "^8.0.5",
-    "babel-plugin-relay": "^10.1.0",
+    "babel-plugin-relay": "11.0.2",
     "cross-env": "6.0.3",
-    "relay-compiler": "^10.1.0",
-    "relay-compiler-language-typescript": "13.0.2",
-    "typescript": "^3.7.3"
+    "relay-compiler": "11.0.2",
+    "relay-compiler-language-typescript": "14.0.0",
+    "typescript": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "lib/index.js",
   "module": "./lib/es/index.js",
-  "unpkg": "lib/umd-relay-hooks.min.js",
+  "unpkg": "lib/umd/relay-hooks.min.js",
   "license": "MIT",
   "description": "Relay Hooks",
   "author": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "ssr"
   ],
   "main": "lib/index.js",
+  "module": "./lib/es/index.js",
+  "unpkg": "lib/umd-relay-hooks.min.js",
   "license": "MIT",
   "description": "Relay Hooks",
   "author": {
@@ -21,7 +23,7 @@
   },
   "scripts": {
     "clean": "rimraf lib",
-    "compile": "npm run clean && tsc && npm run build:js && npm run rollup",
+    "compile": "npm run clean && tsc && tsc --project tsconfig.esm.json && npm run build:js && npm run rollup",
     "rollup": "rollup -c",
     "build": "npm run compile && npm run test",
     "test": "cross-env NODE_ENV=test jest --coverage",
@@ -29,7 +31,7 @@
     "format:ci": "prettier --list-different \"src/**/*.{j,t}s*\"",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "prepublishOnly": "npm run build",
-    "build:js": "babel lib --out-dir lib --extensions \".js,.jsx\""
+    "build:js": "babel lib --out-dir lib --extensions \".js,.jsx\" && babel lib/es --out-dir lib/es --extensions \".js,.jsx\""
   },
   "dependencies": {
     "@restart/hooks": "^0.3.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/camelcase */
 /* eslint-disable import/no-default-export */
-import babel from '@rollup/plugin-babel'
+import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
@@ -24,7 +24,7 @@ function createConfigInternal({ format, production }) {
     return {
         input: 'src/index.ts',
         output: {
-            file: 'lib/' + format + '-relay-hooks' + (production ? '.min' : '') + '.js',
+            file: 'lib/' + format + '/relay-hooks' + (production ? '.min' : '') + '.js',
             format,
             name: 'relay-hooks',
             indent: false,
@@ -94,4 +94,4 @@ function createConfig(format) {
     ];
 }
 
-export default [...createConfig('cjs'), ...createConfig('es'), ...createConfig('umd')];
+export default [...createConfig('umd')];

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "outDir": "lib/es",
+      "rootDir": "src",
+      "module": "ESNext",
+      "target": "es5",
+      "moduleResolution": "node",
+      "noEmitOnError": true,
+      "declaration": true,
+      "lib": ["dom", "es6", "esnext.asynciterable", "es2017.object"],
+      "jsx": "react",
+      "skipLibCheck": true
+    },
+    "exclude": ["lib", "__tests__", "examples", "__mocks__", "coverage", "scripts"],
+    "compileOnSave": true
+  }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,16 +1,7 @@
 {
-    "compilerOptions": {
-      "outDir": "lib/es",
-      "rootDir": "src",
-      "module": "ESNext",
-      "target": "es5",
-      "moduleResolution": "node",
-      "noEmitOnError": true,
-      "declaration": true,
-      "lib": ["dom", "es6", "esnext.asynciterable", "es2017.object"],
-      "jsx": "react",
-      "skipLibCheck": true
-    },
-    "exclude": ["lib", "__tests__", "examples", "__mocks__", "coverage", "scripts"],
-    "compileOnSave": true
-  }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./lib/es"
+  },
+}


### PR DESCRIPTION
This PR is an alternative version to https://github.com/relay-tools/relay-hooks/pull/161 and revisiting the first version in which rollup was integrated https://github.com/relay-tools/relay-hooks/pull/106

I have tried and it works with both CRA applications, NextJS and using the library in react-relay-offline.

@n1ru4l what do you think about it? 

