### PR TITLE
[proposal] Add relay-forms in relay-hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn.lock
 package-lock.json
 !/package-lock.json
 .vscode
+yarn-error.log
+ignore-queries.json

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,6 @@ rollup.config.js
 .vscode
 .babelrc.js
 tsconfig.esm.json
+relay-compiler-forms/
+forms.graphql
+ignore-queries.json

--- a/__tests__/forms-test.tsx
+++ b/__tests__/forms-test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import * as React from 'react';
+import { Form, getFieldError, HAVE_ERRORS, validateEmail, validateFirstName } from './forms';
+jest.useRealTimers();
+
+describe('relay-forms', () => {
+    beforeEach(() => {});
+
+    afterEach(async () => {
+        cleanup();
+
+        jest.clearAllMocks();
+        jest.clearAllTimers();
+        await Promise.resolve();
+    });
+
+    test('do again validation', async () => {
+        const { queryByTestId, getByTestId } = render(<Form></Form>);
+        const input = getByTestId('email') as HTMLInputElement;
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.change(input, { target: { value: '123' } });
+        fireEvent.change(input, { target: { value: '12' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve();
+        expect(getByTestId('email-error').textContent).toBe(getFieldError('email', '12'));
+        expect(getByTestId('email-count').textContent).toBe('2');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+    });
+
+    test('show error in field', () => {
+        const { queryByTestId, getByTestId } = render(<Form></Form>);
+        const input = getByTestId('email') as HTMLInputElement;
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.change(input, { target: { value: '123' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.click(getByTestId('button-submit'));
+        expect(getByTestId('email-error').textContent).toBe(getFieldError('email', '123'));
+        // refresh for isSubmitting
+        expect(getByTestId('email-count').textContent).toBe('2');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+    });
+
+    test('change error in field after submit', async () => {
+        const { queryByTestId, getByTestId } = render(<Form></Form>);
+        const input = getByTestId('email') as HTMLInputElement;
+
+        fireEvent.change(input, { target: { value: '123' } });
+
+        expect(validateEmail).not.toHaveBeenCalled();
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(validateEmail).toBeCalledTimes(1);
+        expect(validateFirstName).toBeCalledTimes(1);
+        expect(getByTestId('email-error').textContent).toBe(getFieldError('email', '123'));
+        expect(getByTestId('errors').textContent).toBe(HAVE_ERRORS);
+        expect(getByTestId('email-count').textContent).toBe('2');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+
+        fireEvent.change(input, { target: { value: '1234' } });
+
+        expect(validateEmail).toBeCalledTimes(2);
+        expect(validateFirstName).toBeCalledTimes(1);
+        expect(getByTestId('email-count').textContent).toBe('3');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        expect(getByTestId('errors').textContent).toBe(HAVE_ERRORS);
+        expect(getByTestId('email-error').textContent).toBe(getFieldError('email', '1234'));
+
+        fireEvent.change(input, { target: { value: '12345' } });
+
+        expect(validateEmail).toBeCalledTimes(3);
+        expect(validateFirstName).toBeCalledTimes(1);
+        expect(getByTestId('email-count').textContent).toBe('4');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+        expect(validateEmail).toBeCalledTimes(3);
+        expect(validateFirstName).toBeCalledTimes(1);
+    });
+
+    test('submit', async () => {
+        const { getByTestId, queryByTestId } = render(<Form></Form>);
+        fireEvent.change(getByTestId('email'), { target: { value: 'email@try.it' } });
+        fireEvent.change(getByTestId('firstName'), { target: { value: 'lorenzo' } });
+        fireEvent.change(getByTestId('lastName'), { target: { value: 'di giacomo' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+        expect(queryByTestId('submit-done')).toBeNull();
+
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+    });
+
+    test('submit promise', async () => {
+        const { getByTestId, queryByTestId } = render(<Form promise></Form>);
+        fireEvent.change(getByTestId('email'), { target: { value: 'email@try.it' } });
+        fireEvent.change(getByTestId('firstName'), { target: { value: 'lorenzo' } });
+        fireEvent.change(getByTestId('lastName'), { target: { value: 'di giacomo' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+        expect(queryByTestId('submit-done')).toBeNull();
+
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+    });
+
+    test('show error in field only validate', async () => {
+        const { queryByTestId, getByTestId } = render(<Form></Form>);
+        const input = getByTestId('email') as HTMLInputElement;
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.change(input, { target: { value: '123' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('email-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.click(getByTestId('button-validate'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(getByTestId('email-error').textContent).toBe(getFieldError('email', '123'));
+        // refresh for isSubmitting
+        expect(getByTestId('email-count').textContent).toBe('2');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+    });
+
+    test('manual validate & submit', async () => {
+        const { getByTestId, queryByTestId } = render(<Form></Form>);
+        fireEvent.change(getByTestId('email'), { target: { value: 'email@try.it' } });
+        fireEvent.change(getByTestId('firstName'), { target: { value: 'lorenzo' } });
+        fireEvent.change(getByTestId('lastName'), { target: { value: 'di giacomo' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+        expect(queryByTestId('submit-done')).toBeNull();
+
+        fireEvent.click(getByTestId('button-validate'));
+        expect(getByTestId('isSubmitting').textContent).toBe('false');
+        expect(getByTestId('isValidating').textContent).toBe('true');
+        await Promise.resolve(); //await promise validation;
+        expect(getByTestId('isValidating').textContent).toBe('false');
+
+        fireEvent.click(getByTestId('button-submit'));
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+    });
+
+    test('submit isSubmitting', async () => {
+        const { getByTestId, queryByTestId } = render(<Form promise></Form>);
+        fireEvent.change(getByTestId('email'), { target: { value: 'email@try.it' } });
+        fireEvent.change(getByTestId('firstName'), { target: { value: 'lorenzo' } });
+        fireEvent.change(getByTestId('lastName'), { target: { value: 'di giacomo' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+        expect(queryByTestId('submit-done')).toBeNull();
+
+        fireEvent.click(getByTestId('button-submit'));
+        expect(getByTestId('isSubmitting').textContent).toBe('true');
+        expect(getByTestId('isValidating').textContent).toBe('true');
+        await Promise.resolve(); //await promise validation;
+        expect(getByTestId('isValidating').textContent).toBe('false');
+        expect(getByTestId('isSubmitting').textContent).toBe('true');
+
+        await Promise.resolve(); //await promise submit;
+        expect(getByTestId('isSubmitting').textContent).toBe('false');
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+    });
+
+    test('show error in complex field', () => {
+        const { queryByTestId, getByTestId } = render(<Form></Form>);
+        const input = getByTestId('complex') as HTMLInputElement;
+        expect(getByTestId('complex-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.change(input, { target: { value: '123' } });
+        expect(queryByTestId('complex-error')).toBeNull();
+        expect(getByTestId('complex-count').textContent).toBe('1');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+        fireEvent.click(getByTestId('button-submit'));
+        expect(getByTestId('complex-error').textContent).toBe(getFieldError('complex', '123'));
+        // refresh for isSubmitting
+        expect(getByTestId('complex-count').textContent).toBe('2');
+        expect(getByTestId('lastName-count').textContent).toBe('1');
+    });
+
+    test('submit complex field', async () => {
+        let result;
+        function onSubmit(values: any): void {
+            result = values;
+        }
+        const { queryByTestId, getByTestId } = render(<Form jestOnSubmit={onSubmit}></Form>);
+
+        fireEvent.change(getByTestId('email'), { target: { value: 'email@try.it' } });
+        fireEvent.change(getByTestId('firstName'), { target: { value: 'lorenzo' } });
+        fireEvent.change(getByTestId('lastName'), { target: { value: 'di giacomo' } });
+
+        fireEvent.change(getByTestId('complex'), { target: { value: 'very complex' } });
+        expect(queryByTestId('email-error')).toBeNull();
+        expect(getByTestId('errors').textContent).toBe('');
+        expect(queryByTestId('submit-done')).toBeNull();
+
+        fireEvent.click(getByTestId('button-submit'));
+        await Promise.resolve(); //await promise validation;
+
+        expect(queryByTestId('submit-done').textContent).toBe('SUBMIT :)');
+        expect(result).toEqual({
+            firstName: 'lorenzo',
+            lastName: 'di giacomo',
+            email: 'email@try.it',
+            complex: { test: 'very complex' },
+        });
+    });
+});

--- a/__tests__/forms.tsx
+++ b/__tests__/forms.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable no-duplicate-imports */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as React from 'react';
+import { useCallback } from 'react';
+import {
+    Environment,
+    Network,
+    RecordSource,
+    Store,
+    RequestParameters,
+    Variables,
+} from 'relay-runtime';
+import { RelayForm, useFormSubmit, useFormState, useFormSetValue } from '../src/forms';
+
+async function fetchQuery(operation: RequestParameters, variables: Variables) {
+    const response = await fetch('http://localhost:3000/graphql', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            query: operation.text,
+            variables,
+        }),
+    });
+
+    return response.json();
+}
+
+export const environment: Environment = new Environment({
+    network: Network.create(fetchQuery),
+    store: new Store(new RecordSource(), { gcReleaseBufferSize: 0 }),
+});
+
+interface Props {
+    promise?: boolean;
+    jestOnSubmit?: (values: any) => void;
+}
+
+export const Form: React.FC<Props> = ({ promise, jestOnSubmit }) => {
+    const [state, setState] = React.useState(undefined);
+
+    const submit = React.useCallback(
+        (values) => {
+            jestOnSubmit && jestOnSubmit(values);
+            setState(values);
+        },
+        [setState, jestOnSubmit],
+    );
+    return (
+        <RelayForm environment={environment}>
+            <FormInternal
+                onSubmit={promise ? (values) => Promise.resolve(submit(values)) : submit}
+            />
+            {state && <div data-testid={'submit-done'}>SUBMIT :)</div>}
+        </RelayForm>
+    );
+};
+
+export const HAVE_ERRORS = 'have errors';
+
+export const Errors: React.FC<any> = () => {
+    const { errors, isSubmitting, isValidating } = useFormState();
+    return (
+        <>
+            <div data-testid={'errors'}>{errors ? HAVE_ERRORS : ''}</div>;
+            <div data-testid={'isSubmitting'}>{'' + isSubmitting}</div>;
+            <div data-testid={'isValidating'}>{'' + isValidating}</div>;
+        </>
+    );
+};
+
+const validateField = jest.fn((value: any, name: string) => {
+    if (value && value.length < 5) {
+        return getFieldError(name, value);
+    }
+    return undefined;
+});
+
+const validatePromiseField = jest.fn((value: any, name: string) => {
+    if (value && value.length < 5) {
+        return Promise.resolve(getFieldError(name, value));
+    }
+    return Promise.resolve(undefined);
+});
+
+const validateComplex = jest.fn((value: any, name: string) => {
+    if (value && value.test && value.test.length < 5) {
+        return getFieldError(name, value.test);
+    }
+    return undefined;
+});
+
+export const validateEmail = jest.fn(validateField);
+
+export const validateFirstName = jest.fn(validatePromiseField);
+
+//export const validateLastName = jest.fn(validateField);
+
+export const FormInternal: React.FC<any> = ({ onSubmit }) => {
+    const data = useFormSubmit({ onSubmit });
+
+    return (
+        <form onSubmit={data.submit} action="#">
+            <div>
+                <Field fieldKey="firstName" placeholder="first name" validate={validateFirstName} />
+            </div>
+            <div>
+                <Field fieldKey="lastName" placeholder="last name" />
+            </div>
+            <div>
+                <Field fieldKey="email" placeholder="email" validate={validateEmail} />
+            </div>
+            <div>
+                <Field fieldKey="complex" placeholder="complex" validate={validateComplex} />
+            </div>
+            <Errors />
+            <button type="button" data-testid={'button-validate'} onClick={data.validate}>
+                only validate
+            </button>
+            <button data-testid={'button-submit'} type="submit">
+                submit
+            </button>
+        </form>
+    );
+};
+
+export const getFieldError = (name, value) =>
+    name + ' wrong length, minimum 5 current ' + value.length;
+
+export const Field: React.FC<any> = ({ placeholder, fieldKey, validate }) => {
+    const ref = React.useRef(0);
+
+    const validateCallback = useCallback(
+        (value: any) => {
+            return validate(value, fieldKey);
+        },
+        [fieldKey, validate],
+    );
+
+    const [{ error }, setValue] = useFormSetValue({
+        key: fieldKey,
+        validate: validate ? validateCallback : undefined,
+        initialValue: 1,
+    });
+
+    const setValueCallback = useCallback(
+        (event) => {
+            const value = event.target.value;
+            if (fieldKey === 'complex') {
+                setValue({
+                    test: value,
+                });
+            } else {
+                setValue(value);
+            }
+        },
+        [fieldKey, setValue],
+    );
+    ref.current += 1;
+    return (
+        <>
+            {error && <div data-testid={fieldKey + '-error'}>{error}</div>}
+            <input
+                data-testid={fieldKey}
+                type="text"
+                value="1"
+                placeholder={placeholder}
+                onChange={(value) => setValueCallback(value)}
+            />
+            <div data-testid={fieldKey + '-count'}>{ref.current}</div>
+        </>
+    );
+};

--- a/forms.graphql
+++ b/forms.graphql
@@ -1,0 +1,17 @@
+type Query {
+  form: EntryForm
+}
+
+type EntryForm {
+  isSubmitting: Boolean
+  isValidating: Boolean
+  entries: [Entry]
+}
+
+type Entry {
+  id: ID!
+  key: String!
+  value: String
+  check: String
+  error: String
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3694,6 +3694,223 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.31.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
+      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.6",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
+          "integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.19.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+          "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "core-js-pure": {
+          "version": "3.19.1",
+          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.1.tgz",
+          "integrity": "sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.0.4.tgz",
+      "integrity": "sha512-2e1B5debfuiIGbvUuiSXybskuh7ZTVJDDvG/IxlzLOY9Co/mKFj9hIklAe2nGZYcOUxFaiqWrRZ9vCVGzJfRlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "@testing-library/dom": "^7.2.2",
+        "@types/testing-library__react": "^10.0.1"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -3914,6 +4131,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__react": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.2.0.tgz",
+      "integrity": "sha512-KbU7qVfEwml8G5KFxM+xEfentAAVj/SOQSjW0+HqzjPE0cXpt0IpSamfX4jGYCImznDHgQcfXBPajS7HjLZduw==",
+      "dev": true,
+      "requires": {
+        "@testing-library/react": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
@@ -5946,6 +6172,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "domexception": {
       "version": "1.0.1",
@@ -10246,6 +10478,12 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -11826,6 +12064,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-dom": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+      "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.17.0"
+      }
+    },
     "react-is": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
@@ -12576,6 +12826,24 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "relay-compiler-language-typescript": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler-language-typescript/-/relay-compiler-language-typescript-12.0.0.tgz",
+      "integrity": "sha512-jTg6aO3FcC6P1mnp6AKdfJcwGx8WQ+ui3HQz9Wn25SbKiqzW4FHBAg9Q38cS/YYOk7a4otcYQPLIcaKE0HXksg==",
+      "dev": true,
+      "requires": {
+        "immutable": "^4.0.0-rc.12",
+        "invariant": "^2.2.4"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+          "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "clean": "rimraf lib",
+    "relay-compiler-forms": "relay-compiler --src ./relay-compiler-forms/ --schema ./forms.graphql --language typescript --artifactDirectory ./src/forms/relay --persist-output ./ignore-queries.json",
     "compile": "npm run clean && tsc && tsc --project tsconfig.esm.json && npm run build:js && npm run build:replace && npm run rollup",
     "rollup": "rollup -c",
     "build": "npm run compile && npm run test",
@@ -76,7 +77,9 @@
     "prettier": "1.19.1",
     "promise-polyfill": "6.1.0",
     "react": "16.11.0",
+    "react-dom": "16.11.0",
     "react-test-renderer": "16.11.0",
+    "relay-compiler-language-typescript": "12.0.0",
     "relay-runtime": "^12.0.0",
     "relay-test-utils": "^12.0.0",
     "relay-test-utils-internal": "^12.0.0",
@@ -86,7 +89,8 @@
     "rollup-plugin-terser": "^6.1.0",
     "rollup-plugin-typescript2": "^0.27.1",
     "ts-jest": "24.1.0",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "@testing-library/react": "10.0.4"
   },
   "funding": {
     "url": "https://github.com/sponsors/morrys"

--- a/relay-compiler-forms/query.tsx
+++ b/relay-compiler-forms/query.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { graphql } from 'relay-runtime';
+
+const QueryField = graphql`
+    query queryFieldQuery {
+        form {
+            entries {
+                id
+                key
+                value
+                check
+                error
+            }
+        }
+    }
+`;
+
+const QueryErrorsField = graphql`
+    query queryErrorsFieldQuery {
+        form {
+            isSubmitting
+            isValidating
+            entries {
+                id
+                key
+                error
+                check
+            }
+        }
+    }
+`;
+
+const FragmentField = graphql`
+    fragment queryFieldFragment on Entry {
+        id
+        check
+    }
+`;
+
+const FragmentValueField = graphql`
+    fragment queryValueFieldFragment on Entry {
+        id
+        value
+        error
+    }
+`;

--- a/src/forms/RelayForm.tsx
+++ b/src/forms/RelayForm.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { IEnvironment } from 'relay-runtime';
+import { operationQueryForm, initialCommit } from './Utils';
+
+const FormContext = React.createContext(null);
+
+export const RelayForm = function(props: {
+    children: React.ReactNode;
+    environment: IEnvironment;
+}): JSX.Element {
+    const { children, environment } = props;
+    const context = React.useMemo(() => ({ environment }), [environment]);
+
+    initialCommit(props.environment);
+
+    React.useEffect(() => {
+        const disposable = environment.retain(operationQueryForm);
+        return disposable.dispose;
+    }, [environment]);
+
+    return <FormContext.Provider value={context}>{children}</FormContext.Provider>;
+};
+
+export function useRelayEnvironment(): IEnvironment {
+    const { environment } = React.useContext(FormContext);
+    return environment;
+}

--- a/src/forms/RelayFormsTypes.ts
+++ b/src/forms/RelayFormsTypes.ts
@@ -1,0 +1,49 @@
+export type FunctionOnSubmit<ValueType> = (values: ValueType) => Promise<void> | void;
+
+export type FormSubmitOptions<ValueType> = {
+    onSubmit: FunctionOnSubmit<ValueType>;
+};
+
+export type FormSubmitReturn = {
+    submit: (event?: React.BaseSyntheticEvent<any, any, any>) => void;
+    validate: () => void;
+};
+
+export type FormSetValueOptions<ValueType> = {
+    key: string;
+    initialValue?: ValueType;
+    validate?: (value: ValueType) => Promise<string | undefined> | string | undefined;
+    validateOnChange?: boolean;
+};
+
+export type FormSetValueStateReturn = {
+    error: undefined | null | Error;
+};
+
+export type FormValueStateReturn<ValueType> = {
+    readonly id: string;
+    readonly value: ValueType | null;
+    readonly error: string | null;
+};
+
+export type FormSetValueFunctionReturn<ValueType> = (newValue: ValueType) => void;
+
+export type FormSetValueReturn<ValueType> = [
+    FormSetValueStateReturn,
+    FormSetValueFunctionReturn<ValueType>,
+];
+
+export type FormStateReturn = {
+    errors: ReadonlyArray<
+        | {
+              readonly id: string;
+              readonly key: string;
+              readonly error: string | null;
+          }
+        | null
+        | undefined
+    >;
+    isValidating: boolean;
+    isSubmitting: boolean;
+    isValid: boolean;
+};

--- a/src/forms/Utils.ts
+++ b/src/forms/Utils.ts
@@ -1,0 +1,93 @@
+import {
+    commitLocalUpdate,
+    createOperationDescriptor,
+    IEnvironment,
+    ROOT_ID,
+    RecordSource,
+    ID_KEY,
+} from 'relay-runtime';
+import QueryErrorsField from './relay/queryErrorsFieldQuery.graphql';
+import QueryField from './relay/queryFieldQuery.graphql';
+
+const PREFIX_LOCAL_FORM = 'local:form';
+
+export function getFieldId(key): string {
+    return PREFIX_LOCAL_FORM + '.' + key;
+}
+
+export const initialCommit = (environment: IEnvironment): void => {
+    commitLocalUpdate(environment, (store) => {
+        const exists = !!store.get(PREFIX_LOCAL_FORM);
+
+        if (!exists) {
+            const localForm = store.create(PREFIX_LOCAL_FORM, 'EntryForm');
+            localForm.setLinkedRecords([], 'entries');
+            const root = store.get(ROOT_ID) || store.getRoot();
+            root.setLinkedRecord(localForm, 'form');
+        }
+    });
+};
+
+export const commitValidateIntoRelay = (entries, isSubmitting, environment): void => {
+    commitLocalUpdate(environment, (store) => {
+        const form = store.get(PREFIX_LOCAL_FORM);
+        form.setValue(isSubmitting, 'isSubmitting');
+        form.setValue(true, 'isValidating');
+        entries.forEach((entry) => store.get(getFieldId(entry.key)).setValue('START', 'check'));
+    });
+};
+
+export const commitSubmitEndRelay = (environment): void => {
+    commitLocalUpdate(environment, (store) => {
+        store.get(PREFIX_LOCAL_FORM) &&
+            store.get(PREFIX_LOCAL_FORM).setValue(false, 'isSubmitting');
+    });
+};
+
+export const commitValidateEndRelay = (environment): void => {
+    commitLocalUpdate(environment, (store) => {
+        store.get(PREFIX_LOCAL_FORM) &&
+            store.get(PREFIX_LOCAL_FORM).setValue(false, 'isValidating');
+    });
+};
+
+export const commitValue = (key, value, check, environment, validate): void => {
+    const id = getFieldId(key);
+    commitLocalUpdate(environment, (store) => {
+        const localForm = store.get(PREFIX_LOCAL_FORM);
+        if (!store.get(id)) {
+            const root = store.create(id, 'Entry');
+            root.setValue(id, 'id');
+            root.setValue(key, 'key');
+            root.setValue(validate ? 'INIT' : 'DONE', 'check');
+            const entriesArray = localForm.getLinkedRecords('entries') || [];
+            entriesArray.push(root);
+            localForm.setLinkedRecords(entriesArray, 'entries');
+        }
+    });
+
+    const field = {
+        [ID_KEY]: id,
+        value,
+        __typename: 'Entry',
+    } as any;
+    const source = new RecordSource();
+    if (check === 'DONE' && validate) {
+        field.check = 'START';
+    }
+    source.set(id, field);
+    environment._publishQueue.commitSource(source);
+    environment._publishQueue.run();
+};
+
+export const commitErrorIntoRelay = (key, error, environment): void => {
+    commitLocalUpdate(environment, (store) => {
+        const root = store.get(getFieldId(key));
+        root.setValue(error, 'error');
+        root.setValue('DONE', 'check');
+    });
+};
+
+export const operationQueryForm = createOperationDescriptor(QueryField, {});
+
+export const operationQueryErrorsForm = createOperationDescriptor(QueryErrorsField, {});

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -1,0 +1,7 @@
+export { useFormState } from './useFormState';
+export { useFormSubmit } from './useFormSubmit';
+export { RelayForm } from './RelayForm';
+export { useFormSetValue } from './useFormSetValue';
+export { useFormValue } from './useFormValue';
+
+export * from './RelayFormsTypes';

--- a/src/forms/relay/queryErrorsFieldQuery.graphql.ts
+++ b/src/forms/relay/queryErrorsFieldQuery.graphql.ts
@@ -1,0 +1,135 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash bcada931a45af33846035fd01b1513e8 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type queryErrorsFieldQueryVariables = {};
+export type queryErrorsFieldQueryResponse = {
+    readonly form: {
+        readonly isSubmitting: boolean | null;
+        readonly isValidating: boolean | null;
+        readonly entries: ReadonlyArray<{
+            readonly id: string;
+            readonly key: string;
+            readonly error: string | null;
+            readonly check: string | null;
+        } | null> | null;
+    } | null;
+};
+export type queryErrorsFieldQuery = {
+    readonly response: queryErrorsFieldQueryResponse;
+    readonly variables: queryErrorsFieldQueryVariables;
+};
+
+
+
+/*
+query queryErrorsFieldQuery {
+  form {
+    isSubmitting
+    isValidating
+    entries {
+      id
+      key
+      error
+      check
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EntryForm",
+    "kind": "LinkedField",
+    "name": "form",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isSubmitting",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "isValidating",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Entry",
+        "kind": "LinkedField",
+        "name": "entries",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "key",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "error",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "check",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "queryErrorsFieldQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "queryErrorsFieldQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": "bcada931a45af33846035fd01b1513e8",
+    "metadata": {},
+    "name": "queryErrorsFieldQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '9f2fbcaf6e15ad88e2697391bda17a99';
+export default node;

--- a/src/forms/relay/queryFieldFragment.graphql.ts
+++ b/src/forms/relay/queryFieldFragment.graphql.ts
@@ -1,0 +1,44 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type queryFieldFragment = {
+    readonly id: string;
+    readonly check: string | null;
+    readonly " $refType": "queryFieldFragment";
+};
+export type queryFieldFragment$data = queryFieldFragment;
+export type queryFieldFragment$key = {
+    readonly " $data"?: queryFieldFragment$data;
+    readonly " $fragmentRefs": FragmentRefs<"queryFieldFragment">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "queryFieldFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "check",
+      "storageKey": null
+    }
+  ],
+  "type": "Entry",
+  "abstractKey": null
+};
+(node as any).hash = 'd5b0953bdeb412925ee13444a6be6082';
+export default node;

--- a/src/forms/relay/queryFieldQuery.graphql.ts
+++ b/src/forms/relay/queryFieldQuery.graphql.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 0b493a6f66e132f2693f91a5da941414 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type queryFieldQueryVariables = {};
+export type queryFieldQueryResponse = {
+    readonly form: {
+        readonly entries: ReadonlyArray<{
+            readonly id: string;
+            readonly key: string;
+            readonly value: string | null;
+            readonly check: string | null;
+            readonly error: string | null;
+        } | null> | null;
+    } | null;
+};
+export type queryFieldQuery = {
+    readonly response: queryFieldQueryResponse;
+    readonly variables: queryFieldQueryVariables;
+};
+
+
+
+/*
+query queryFieldQuery {
+  form {
+    entries {
+      id
+      key
+      value
+      check
+      error
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EntryForm",
+    "kind": "LinkedField",
+    "name": "form",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Entry",
+        "kind": "LinkedField",
+        "name": "entries",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "key",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "value",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "check",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "error",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "queryFieldQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "queryFieldQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "id": "0b493a6f66e132f2693f91a5da941414",
+    "metadata": {},
+    "name": "queryFieldQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'f9fd20a80a839dfb51206c305cbb1657';
+export default node;

--- a/src/forms/relay/queryValueFieldFragment.graphql.ts
+++ b/src/forms/relay/queryValueFieldFragment.graphql.ts
@@ -1,0 +1,52 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type queryValueFieldFragment = {
+    readonly id: string;
+    readonly value: string | null;
+    readonly error: string | null;
+    readonly " $refType": "queryValueFieldFragment";
+};
+export type queryValueFieldFragment$data = queryValueFieldFragment;
+export type queryValueFieldFragment$key = {
+    readonly " $data"?: queryValueFieldFragment$data;
+    readonly " $fragmentRefs": FragmentRefs<"queryValueFieldFragment">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "queryValueFieldFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "value",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "error",
+      "storageKey": null
+    }
+  ],
+  "type": "Entry",
+  "abstractKey": null
+};
+(node as any).hash = 'b63b485c6f0bf3d1d4f796302a2229d8';
+export default node;

--- a/src/forms/useFormSetValue.tsx
+++ b/src/forms/useFormSetValue.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Snapshot, getSingularSelector, isPromise } from 'relay-runtime';
+import FragmentField, { queryFieldFragment$data } from './relay/queryFieldFragment.graphql';
+import { useRelayEnvironment } from './RelayForm';
+import { FormSetValueOptions, FormSetValueReturn } from './RelayFormsTypes';
+import { getFieldId, operationQueryForm, commitValue, commitErrorIntoRelay } from './Utils';
+
+export function useFormSetValue<ValueType>({
+    key,
+    initialValue,
+    validate,
+    validateOnChange,
+}: FormSetValueOptions<ValueType>): FormSetValueReturn<ValueType> {
+    const [, forceUpdate] = React.useState(undefined);
+    const environment = useRelayEnvironment();
+    const ref = React.useRef({
+        value: initialValue,
+        error: undefined,
+        touched: true,
+        check: validate ? 'INIT' : 'DONE',
+        isChecking: false,
+    });
+
+    const setValue = React.useCallback(
+        (newValue) => {
+            ref.current.value = newValue;
+            ref.current.touched = true;
+            commitValue(key, newValue, ref.current.check, environment, validate);
+        },
+        [environment, key, validate],
+    );
+
+    React.useEffect(() => {
+        setValue(initialValue);
+        const fragment = FragmentField;
+        const item = {
+            __fragmentOwner: operationQueryForm,
+            __fragments: { queryFieldFragment: {} },
+            __id: getFieldId(key),
+        };
+        const selector = getSingularSelector(fragment, item);
+        const snapshot = environment.lookup(selector);
+
+        const dispose = environment.subscribe(snapshot, (s: Snapshot) => {
+            const data: queryFieldFragment$data = (s as any).data;
+            const isStart = data.check === 'START';
+            ref.current.check = data.check;
+            if (!validate) {
+                commitErrorIntoRelay(key, undefined, environment);
+                return;
+            }
+            if (isStart && !ref.current.isChecking) {
+                internalValidate(ref.current.value);
+            }
+        }).dispose;
+
+        function finalizeCheck(error): void {
+            ref.current.isChecking = false;
+            ref.current.touched = false;
+            if (ref.current.error !== error) {
+                ref.current.error = error;
+                forceUpdate(error);
+            }
+            commitErrorIntoRelay(key, error, environment);
+        }
+
+        function internalValidate(value): void {
+            ref.current.isChecking = true;
+            const result = validate(value);
+            function internalFinalize(error): void {
+                if (value !== ref.current.value) {
+                    internalValidate(ref.current.value);
+                    return;
+                }
+                finalizeCheck(error);
+            }
+            if (isPromise(result)) {
+                (result as Promise<string | undefined>)
+                    .then(internalFinalize)
+                    .catch(internalFinalize);
+            } else {
+                internalFinalize(result);
+            }
+        }
+        if (validateOnChange) {
+            internalValidate(initialValue);
+        }
+        return dispose;
+    }, [environment, initialValue, key, setValue, validate, validateOnChange]);
+
+    return [ref.current, setValue];
+}

--- a/src/forms/useFormState.tsx
+++ b/src/forms/useFormState.tsx
@@ -1,0 +1,54 @@
+import * as areEqual from 'fbjs/lib/areEqual';
+import * as React from 'react';
+import { Snapshot } from 'relay-runtime';
+import { queryErrorsFieldQueryResponse } from './relay/queryErrorsFieldQuery.graphql';
+import { useRelayEnvironment } from './RelayForm';
+import { FormStateReturn } from './RelayFormsTypes';
+import { operationQueryErrorsForm } from './Utils';
+
+export const useFormState = (): FormStateReturn => {
+    const ref = React.useRef<FormStateReturn>({
+        errors: undefined,
+        isValidating: false,
+        isSubmitting: false,
+        isValid: false,
+    });
+
+    const [, forceUpdate] = React.useState(ref.current);
+    const environment = useRelayEnvironment();
+
+    React.useEffect(() => {
+        const snapshot = environment.lookup(operationQueryErrorsForm.fragment);
+        function checkError(s: Snapshot): void {
+            const data: queryErrorsFieldQueryResponse = (s as any).data;
+            const entryErrors = data.form.entries.filter((value) => !!value.error);
+            const entryValidated = data.form.entries.filter((value) => value.check === 'DONE');
+            const errors = entryErrors.length > 0 ? entryErrors : undefined;
+
+            const isValid =
+                data.form.entries.length === entryValidated.length &&
+                (!errors || Object.keys(errors).length === 0);
+            if (
+                !areEqual(ref.current.errors, errors) ||
+                ref.current.isValid !== isValid ||
+                ref.current.isValidating !== data.form.isValidating ||
+                ref.current.isSubmitting !== data.form.isSubmitting
+            ) {
+                const newState = {
+                    errors,
+                    isValid,
+                    isValidating: data.form.isValidating,
+                    isSubmitting: data.form.isSubmitting,
+                };
+                ref.current = newState;
+                forceUpdate(ref.current);
+            }
+        }
+        checkError(snapshot);
+        return environment.subscribe(snapshot, (s) => {
+            checkError(s);
+        }).dispose;
+    }, [environment]);
+
+    return ref.current;
+};

--- a/src/forms/useFormSubmit.tsx
+++ b/src/forms/useFormSubmit.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { Snapshot, isPromise, IEnvironment } from 'relay-runtime';
+import { queryFieldQueryResponse } from './relay/queryFieldQuery.graphql';
+import { useRelayEnvironment } from './RelayForm';
+import { FormSubmitOptions, FunctionOnSubmit, FormSubmitReturn } from './RelayFormsTypes';
+import {
+    commitValidateEndRelay,
+    commitValidateIntoRelay,
+    commitSubmitEndRelay,
+    operationQueryForm,
+} from './Utils';
+
+function execute(
+    environment: IEnvironment,
+    snapshot: Snapshot,
+    dispose: () => void,
+    onSubmit?: FunctionOnSubmit<object>,
+): void {
+    const data: queryFieldQueryResponse = (snapshot as any).data;
+    const filtered = data.form.entries.filter((value) => value.check === 'DONE');
+    if (filtered.length === data.form.entries.length) {
+        const errors = data.form.entries.filter((value) => !!value.error);
+        commitValidateEndRelay(environment);
+        if (onSubmit && (!errors || errors.length === 0)) {
+            const result = {};
+            data.form.entries.forEach((entry) => {
+                result[entry.key] = entry.value;
+            });
+            const submit = onSubmit(result);
+            if (isPromise(submit)) {
+                (submit as Promise<void>).then(dispose).catch(dispose);
+            } else {
+                dispose();
+            }
+        } else {
+            dispose();
+        }
+    }
+}
+
+export const useFormSubmit = <ValueType extends object = object>({
+    onSubmit,
+}: FormSubmitOptions<ValueType>): FormSubmitReturn => {
+    const environment = useRelayEnvironment();
+    const ref = React.useRef({
+        isSubmitting: false,
+        isValidating: false,
+        error: undefined,
+    });
+
+    const internalValidate = React.useCallback(
+        (snapshot: Snapshot, isSubmitting) => {
+            ref.current.isValidating = true;
+            const data: queryFieldQueryResponse = (snapshot as any).data;
+            const filtered = data.form.entries.filter((value) => value.check === 'INIT');
+            commitValidateIntoRelay(filtered, isSubmitting, environment);
+        },
+        [environment],
+    );
+
+    const validate = React.useCallback(() => {
+        const snapshot = environment.lookup(operationQueryForm.fragment);
+        if (ref.current.isValidating) {
+            return;
+        }
+        let subscription = null;
+        function dispose(): void {
+            subscription && subscription.dispose();
+            subscription = null;
+            ref.current.isValidating = false;
+        }
+        subscription = environment.subscribe(snapshot, (s) => execute(environment, s, dispose));
+        internalValidate(snapshot, false);
+        execute(environment, snapshot, dispose);
+    }, [environment, internalValidate]);
+
+    const submit = React.useCallback(
+        (event?: React.BaseSyntheticEvent<any>) => {
+            if (event) {
+                event.preventDefault();
+            }
+
+            if (ref.current.isSubmitting) {
+                return;
+            }
+            let subscription = null;
+            function dispose(): void {
+                subscription && subscription.dispose();
+                subscription = null;
+                ref.current.isSubmitting = false;
+                commitSubmitEndRelay(environment);
+            }
+            ref.current.isSubmitting = true;
+            const snapshot = environment.lookup(operationQueryForm.fragment);
+
+            subscription = environment.subscribe(snapshot, (s) =>
+                execute(environment, s, dispose, onSubmit),
+            );
+            internalValidate(snapshot, true);
+            execute(environment, snapshot, dispose, onSubmit);
+        },
+        [environment, internalValidate, onSubmit],
+    );
+
+    const result = React.useMemo(() => {
+        return {
+            submit,
+            validate,
+        };
+    }, [submit, validate]);
+    return result;
+};

--- a/src/forms/useFormValue.tsx
+++ b/src/forms/useFormValue.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Snapshot, getSingularSelector } from 'relay-runtime';
+import FragmentField, {
+    queryValueFieldFragment$data,
+} from './relay/queryValueFieldFragment.graphql';
+import { useRelayEnvironment } from './RelayForm';
+import { FormValueStateReturn } from './RelayFormsTypes';
+import { getFieldId, operationQueryForm } from './Utils';
+
+export function useFormValue<ValueType>(key: string): FormValueStateReturn<ValueType> {
+    const [data, setData] = React.useState<FormValueStateReturn<any>>(undefined);
+    const environment = useRelayEnvironment();
+
+    React.useEffect(() => {
+        const fragment = FragmentField;
+        const item = {
+            __fragmentOwner: operationQueryForm,
+            __fragments: { queryValueFieldFragment: {} },
+            __id: getFieldId(key),
+        };
+        const selector = getSingularSelector(fragment, item);
+        const snapshot = environment.lookup(selector);
+
+        const data: queryValueFieldFragment$data = (snapshot as any).data;
+
+        setData(data);
+
+        return environment.subscribe(snapshot, (s: Snapshot) => {
+            const data: queryValueFieldFragment$data = (s as any).data;
+            setData(data);
+        }).dispose;
+    }, [environment, key, setData]);
+
+    return data;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "jsx": "react",
     "skipLibCheck": true
   },
-  "exclude": ["lib", "__tests__", "examples", "__mocks__", "coverage", "scripts"],
+  "exclude": ["lib", "relay-compiler-forms", "__tests__", "examples", "__mocks__", "coverage", "scripts"],
   "compileOnSave": true
 }


### PR DESCRIPTION
issue: https://github.com/relay-tools/relay-hooks/issues/197

The idea is to integrate my relay-forms library into relay-hooks which allows:
  * dynamic management of form fields
  * a super performing rendering, taking advantage of all the benefits of relay
  * Small bundle compared to current libraries to manage forms
Documentation: [relay-forms](https://morrys.github.io/relay-forms/docs/relay-forms.html)

Things to do:
  * [X] import relay-forms sources into "src/form"
  * [X] integrate tests
  * [ ] update the documentation
  * [ ] integrate sample projects
