### PR TITLE
Emit declarations for function overloads

### DIFF
--- a/src/useFragment.tsx
+++ b/src/useFragment.tsx
@@ -8,7 +8,7 @@ export function useFragment<TKey extends KeyType>(
 ): $Call<KeyReturnType<TKey>>;
 export function useFragment<TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
+    fragmentRef: TKey | null | undefined,
 ): $Call<KeyReturnType<TKey>> | null;
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
@@ -16,7 +16,11 @@ export function useFragment<TKey extends ArrayKeyType>(
 ): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>;
 export function useFragment<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
+    fragmentRef: TKey | null | undefined,
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>;
+export function useFragment<TKey extends ArrayKeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null | undefined,
 ): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>> {
     const [data] = useOssFragment(fragmentNode, fragmentRef, false, FRAGMENT_NAME);
     return data;
@@ -33,6 +37,10 @@ export function useSuspenseFragment<TKey extends KeyType>(
 export function useSuspenseFragment<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
+): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>;
+export function useSuspenseFragment<TKey extends ArrayKeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
 ): ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>;
 export function useSuspenseFragment<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
@@ -55,6 +63,11 @@ export function useFragmentSubscription<TKey extends KeyType>(
 export function useFragmentSubscription<TKey extends ArrayKeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
+    callback: (data: ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>) => void,
+): void;
+export function useFragmentSubscription<TKey extends ArrayKeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
     callback: (data: ReadonlyArray<$Call<ArrayKeyReturnType<TKey>>>) => void,
 ): void;
 export function useFragmentSubscription<TKey extends ArrayKeyType>(

--- a/src/usePagination.ts
+++ b/src/usePagination.ts
@@ -14,11 +14,11 @@ export function usePagination<TQuery extends OperationType, TKey extends KeyType
 ): ReturnTypePagination<TQuery, TKey, KeyTypeData<TKey>>;
 export function usePagination<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
+    fragmentRef: TKey | null | undefined,
 ): ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null>;
 export function usePagination<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
+    fragmentRef: TKey | null | undefined,
 ): ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null> {
     const [data] = useOssFragment(fragmentNode, fragmentRef, false, PAGINATION_NAME);
     return data;

--- a/src/usePagination.ts
+++ b/src/usePagination.ts
@@ -11,13 +11,15 @@ import { useOssFragment } from './useOssFragment';
 export function usePagination<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): // tslint:disable-next-line no-unnecessary-generics
-ReturnTypePagination<TQuery, TKey, KeyTypeData<TKey>>;
+): ReturnTypePagination<TQuery, TKey, KeyTypeData<TKey>>;
 export function usePagination<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): // tslint:disable-next-line no-unnecessary-generics
-ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null> {
+): ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null>;
+export function usePagination<TQuery extends OperationType, TKey extends KeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null> {
     const [data] = useOssFragment(fragmentNode, fragmentRef, false, PAGINATION_NAME);
     return data;
 }
@@ -25,13 +27,15 @@ ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null> {
 export function usePaginationFragment<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
-): // tslint:disable-next-line no-unnecessary-generics
-ReturnTypePaginationSuspense<TQuery, TKey, KeyTypeData<TKey>>;
+): ReturnTypePaginationSuspense<TQuery, TKey, KeyTypeData<TKey>>;
 export function usePaginationFragment<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
-): // tslint:disable-next-line no-unnecessary-generics
-ReturnTypePaginationSuspense<TQuery, TKey | null, KeyTypeData<TKey> | null> {
+): ReturnTypePaginationSuspense<TQuery, TKey | null, KeyTypeData<TKey> | null>;
+export function usePaginationFragment<TQuery extends OperationType, TKey extends KeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+): ReturnTypePaginationSuspense<TQuery, TKey | null, KeyTypeData<TKey> | null> {
     const [data] = useOssFragment(fragmentNode, fragmentRef, true, PAGINATION_NAME);
     return data;
 }
@@ -40,13 +44,16 @@ export function usePaginationSubscription<TQuery extends OperationType, TKey ext
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey,
     callback: (data: ReturnTypePagination<TQuery, TKey, KeyTypeData<TKey>>) => void,
-): // tslint:disable-next-line no-unnecessary-generics
-void;
+): void;
 export function usePaginationSubscription<TQuery extends OperationType, TKey extends KeyType>(
     fragmentNode: GraphQLTaggedNode,
     fragmentRef: TKey | null,
     callback: (data: ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null>) => void,
-): // tslint:disable-next-line no-unnecessary-generics
-void {
+): void;
+export function usePaginationSubscription<TQuery extends OperationType, TKey extends KeyType>(
+    fragmentNode: GraphQLTaggedNode,
+    fragmentRef: TKey | null,
+    callback: (data: ReturnTypePagination<TQuery, TKey | null, KeyTypeData<TKey> | null>) => void,
+): void {
     useOssFragment(fragmentNode, fragmentRef, false, PAGINATION_NAME, callback);
 }


### PR DESCRIPTION
When you have an overloaded function the declaration doesn't emit type on the function body, so you have to duplicate it.

Practically speaking, usePagination does not allow `null` in TypeScript with the current release because that definition is not emitted.

While I was modifying these, I made them also accept `undefined` which you often get from Relay generated types. It is handled the same as null.

## Test Plan

- `npm run compile`
- verify that `lib/usePagination.d.ts` has a `usePagination` definition that accepts null/undefined for the fragmentRef