### PR TITLE
fix(types): RelayEnvironmentProvider should accept IEnvironment

### DIFF
--- a/src/RelayEnvironmentProvider.tsx
+++ b/src/RelayEnvironmentProvider.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import { Environment } from 'relay-runtime';
+import { IEnvironment } from 'relay-runtime';
 import { ReactRelayContext } from './ReactRelayContext'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
-export const RelayEnvironmentProvider = function <TEnvironment extends Environment = Environment>(props: {
-    children: React.ReactNode;
-    environment: TEnvironment;
-}): JSX.Element {
+export function RelayEnvironmentProvider(props: { children: React.ReactNode; environment: IEnvironment }): JSX.Element {
     const context = React.useMemo(() => ({ environment: props.environment }), [props.environment]);
     return <ReactRelayContext.Provider value={context}>{props.children}</ReactRelayContext.Provider>;
-};
+}


### PR DESCRIPTION
`RelayEnvironmentProvider` current accepts only the type `Environment`, which is actually the default export, or `RelayModernEnvironment`. Because of some funny naming by `relay-runtime`, we actually want "any environment", which is `IEnvironment`. This allows us to pass in a mock environment as opposed to a fully-fledged `RelayModernEnvironment`.

I also converted the component to a function for consistency and removed the generic since it isn't necessary.