### PR TITLE
fix(types): Pass TOperationType to usePreloadQuery's loadQuery parameter

### DIFF
--- a/src/usePreloadedQuery.ts
+++ b/src/usePreloadedQuery.ts
@@ -5,7 +5,7 @@ import { useForceUpdate } from './useForceUpdate';
 import { useRelayEnvironment } from './useRelayEnvironment';
 
 export const usePreloadedQuery = <TOperationType extends OperationType = OperationType>(
-    loadQuery: LoadQuery,
+    loadQuery: LoadQuery<TOperationType>,
 ): RenderProps<TOperationType> => {
     const forceUpdate = useForceUpdate();
     const environment = useRelayEnvironment();


### PR DESCRIPTION
When passing a typed LoadQuery<T>, where T has variables, to usePreloadQuery the type of LoadQuery.next will conflict with the default typed LoadQuery in by usePreloadQuery. Not inferring the type of TOperationType from the parameter shape seems like an oversight. 