### PR TITLE
Improve useSubscription hook types

### DIFF
--- a/src/RelayHooksTypes.ts
+++ b/src/RelayHooksTypes.ts
@@ -197,12 +197,10 @@ export interface ReturnTypePaginationSuspense<
     refetch: RefetchFnDynamic<TQuery, TKey>;
 }
 
-export type SubscriptionConfig = {
-    skip?: boolean;
-};
+export type SubscriptionConfig = Record<string, never>; // allows only empty object
 
 export type SkipSubscriptionConfig = {
-    skip: true;
+    skip: boolean;
 };
 
 export interface SkipGraphQLSubscriptionConfig<TSubscription extends OperationType>

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -13,7 +13,7 @@ export function useSubscription<TSubscriptionPayload extends OperationType = Ope
 ): void;
 export function useSubscription<TSubscriptionPayload extends OperationType = OperationType>(
     config: GraphQLSubscriptionConfig<TSubscriptionPayload>,
-    opts?: SubscriptionConfig,
+    opts?: SubscriptionConfig | SkipSubscriptionConfig,
 ): void {
     const environment = useRelayEnvironment();
     const skip = opts && opts.skip;


### PR DESCRIPTION
useSubscription allows to omit `config.subscription` and `config.variables` if `opts.skip` is literally true. 
I.e. `subscription` and `variables` are optional only when we explicitly pass true to skip option: 
`useSubscription(config, { skip: true })`.

But in reality we never do it like this `skip: true`. We always use some variable. For example like this
`useSubscription(config, { skip: !userId })`. 
But in this case with current typescript type if we use `skip: !userId` subscription and variables are required.

This PR makes `config.subscription` and `config.variables` optional whenever we provide skip option. The value of skip option can be known in runtime only.

The problem code example:
```
// userId is required variable in subscription
const subscription = graphql`
  subscription UserUpdates(userId: ID!) {
    userUpdates(id: $userId) {
      ...
    }
  }
`

const Component = ({ userId }: { userId?: string }) => {
  const skip = !userId

  useSubscription({ 
    subscription,

    // variables and userId are required here
    // but I don't have userId, so I have to do something like this 
    variables: {
      userId: skip ? '' : userId // or userId: userId || ''
    } 
  }, { skip })
}
```

With a fix I think code can be clearer:
```
// userId is required variable in subscription
const subscription = graphql`
  subscription UserUpdates(userId: ID!) {
    userUpdates(id: $userId) {
      ...
    }
  }
`

const Component = ({ userId }: { userId?: string }) => {
  const skip = !userId

  useSubscription({ 
    subscription,

    // we cannot make userId optional, but variables are optional now
    variables: skip ? undefined : {
      userId
    } 
  }, { skip })
}
```