### PR TITLE
fix typo react v19

### DIFF
--- a/src/RelayEnvironmentProvider.tsx
+++ b/src/RelayEnvironmentProvider.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { IEnvironment } from 'relay-runtime';
 import { ReactRelayContext } from './ReactRelayContext'; // eslint-disable-line @typescript-eslint/no-unused-vars
 
-export function RelayEnvironmentProvider(props: { children: React.ReactNode; environment: IEnvironment }): JSX.Element {
+export function RelayEnvironmentProvider(props: {
+    children: React.ReactNode;
+    environment: IEnvironment;
+}): React.ReactElement {
     const context = React.useMemo(() => ({ environment: props.environment }), [props.environment]);
     return <ReactRelayContext.Provider value={context}>{props.children}</ReactRelayContext.Provider>;
 }

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -18,7 +18,7 @@ const useInternalQuery = <TOperationType extends OperationType = OperationType>(
 ): RenderProps<TOperationType> => {
     const environment = useRelayEnvironment();
     const forceUpdate = useForceUpdate();
-    const ref = useRef<Reference<TOperationType>>();
+    const ref = useRef<Reference<TOperationType>>(undefined);
     const maybeHiddenOrFastRefresh = useRef(false);
     if (ref.current === null || ref.current === undefined || maybeHiddenOrFastRefresh.current == true) {
         ref.current = {


### PR DESCRIPTION
React v19 and recent @types/react no longer export JSX globally

https://github.com/relay-tools/relay-hooks/issues/286